### PR TITLE
workspace check for table fixed

### DIFF
--- a/util/class.tx_rnbase_util_DB.php
+++ b/util/class.tx_rnbase_util_DB.php
@@ -115,8 +115,8 @@ class tx_rnbase_util_DB {
 			$enableFields = $sysPage->enableFields($tableName, $mode, $ignoreArr);
 			// Wir setzen zusätzlich pid >=0, damit Version-Records nicht erscheinen
 			// allerdings nur, wenn die Tabelle versionierbar ist!
-			if (!empty($GLOBALS['TCA'][$table]['ctrl']['versioningWS'])) {
-				$enableFields .= ' AND '.$tableName.'.pid >=0';
+			if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['versioningWS'])) {
+				$enableFields .= ' AND ' . $tableName . '.pid >=0';
 			}
 			// Replace tablename with alias
 			if($tableAlias)


### PR DESCRIPTION
Bei der Prüfung, ob die Tabelle versioniert werden kann, liegt noch ein kleiner Fehler vor.
Die Variable  `$table` gibt es nicht. Stattdessen muss es `$tableName` lauten.
Sorry, my mistake!
