### PR TITLE
The minus sign has to be escaped in regular expressions.

### DIFF
--- a/util/class.tx_rnbase_util_BaseMarker.php
+++ b/util/class.tx_rnbase_util_BaseMarker.php
@@ -336,13 +336,13 @@ class tx_rnbase_util_BaseMarker {
 	 * @param tx_rnbase_util_FormatUtil $formatter
 	 */
 	protected static function callModuleMarkers($template, &$markerArray, &$params, &$formatter) {
-		preg_match_all('!\<\!--[a-zA-Z0-9 ]*###([A-Z0-9_-|]*)\###[a-zA-Z0-9 ]*-->!is', $template, $match);
+		preg_match_all('!\<\!--[a-zA-Z0-9 ]*###([A-Z0-9_\-|]*)\###[a-zA-Z0-9 ]*-->!is', $template, $match);
 		$allMarkers = array_unique($match[1]);
-		preg_match_all('!\###([A-Z0-9_-|]*)\###!is', $template, $match);
+		preg_match_all('!\###([A-Z0-9_\-|]*)\###!is', $template, $match);
 		$allSingleMarkers = array_unique($match[1]);
 		$allSingleMarkers = array_diff($allSingleMarkers, $allMarkers);
 		foreach ($allSingleMarkers as $marker) {
-			if (preg_match('/MARKERMODULE__([A-Z0-9_-])*/', $marker)) {
+			if (preg_match('/MARKERMODULE__([A-Z0-9_\-])*/', $marker)) {
 				$module = t3lib_div::makeInstanceService('markermodule', substr($marker, 14));
 				if (is_object($module)) {
 					$subTemplate = $formatter->cObj->getSubpart($template, '###'.$marker.'###');
@@ -358,10 +358,10 @@ class tx_rnbase_util_BaseMarker {
 	}
 
 	protected static function callModuleSubparts($template, &$subpartArray, &$wrappedSubpartArray, &$params, &$formatter) {
-		preg_match_all('!\<\!--[a-zA-Z0-9 ]*###([A-Z0-9_-|]*)\###[a-zA-Z0-9 ]*-->!is', $template, $match);
+		preg_match_all('!\<\!--[a-zA-Z0-9 ]*###([A-Z0-9_\-|]*)\###[a-zA-Z0-9 ]*-->!is', $template, $match);
 		$allMarkers = array_unique($match[1]);
 		foreach ($allMarkers as $marker) {
-			if (preg_match('/MARKERMODULE__([A-Z0-9_-])*/', $marker)) {
+			if (preg_match('/MARKERMODULE__([A-Z0-9_\-])*/', $marker)) {
 				$module = t3lib_div :: makeInstanceService('markermodule', substr($marker, 14));
 				if (is_object($module)) {
 					$subTemplate = $formatter->cObj->getSubpart($template, '###'.$marker.'###');


### PR DESCRIPTION
Damit ein Minus in Markernamen möglich ist, muss dieses in den Regulären Ausdrücken escaped werden.
Das Minus ist ansonsten ein Steuerzeichen um einen Bereich zu definieren (`a-z`, `0-9`, ...).
