### PR TITLE
count for queries with groubby, having, what or count in custom what.

### DIFF
--- a/tests/class.tx_rnbase_tests_util_SearchBase_testcase.php
+++ b/tests/class.tx_rnbase_tests_util_SearchBase_testcase.php
@@ -28,7 +28,7 @@ tx_rnbase::load('tx_rnbase_util_DB');
 
 class tx_rnbase_tests_utilSearchBase_testcase extends tx_phpunit_testcase {
 	function test_searchFieldJoinedWithoutValue() {
-		$searcher = tx_rnbase::makeInstance('tx_rnbase_util_SearchGeneric');
+		$searcher = $this->getGenericSearcher();
 		$options = $this->createOptions();
 
 		// Test 1: Fehlerhaften Code in t3users korrigieren. Ein falsch gesetztes SEARCH_FIELD_JOINED muss ignoriert werden
@@ -38,16 +38,110 @@ class tx_rnbase_tests_utilSearchBase_testcase extends tx_phpunit_testcase {
 
 		$this->assertTrue(strpos($ret, 'AND  AND') === FALSE, 'SQL is wrong');
 	}
+
+	/**
+	 */
+	public function testSearchForCount() {
+	 //* @dataProvider getSearchForCountProvider
+		$searcher = $this->getGenericSearcher();
+		$fields = array('FEUSER.uid' => array(OP_EQ_INT => 54));
+		$options = $this->createOptions();
+		$options['count'] = TRUE;
+
+		// SELECT FEUSER.* FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54;
+		$query = $searcher->search($fields, $options);
+
+		// the count should be at the first
+		$this->assertEquals(0, strpos($query, 'SELECT count(*) as cnt FROM'));
+		// check the uid where
+		$this->assertContains(' FEUSER.uid = 54 ', $query);
+
+
+		// SELECT FEUSER.* FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup
+		$options['groupby'] = 'FEUSER.usergroup';
+		$query = $searcher->search($fields, $options);#
+
+		// the count with the subselect should be at the first
+		$this->assertEquals(0, strpos($query, 'SELECT COUNT(COUNTWRAP.uid) as cnt FROM'));
+		// check the uid where
+		$this->assertContains(' FEUSER.uid = 54 ', $query);
+		$this->assertContains(' GROUP BY FEUSER.usergroup', $query);
+		// the closing subselect should be at the last
+		$this->assertEquals(
+			strlen($query) - strlen(') as COUNTWRAP WHERE 1=1'),
+			strpos($query, ') as COUNTWRAP WHERE 1=1')
+		);
+
+
+		// SELECT COUNT(FEUSER.uid) FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup
+		$options['what'] = 'COUNT(FEUSER.uid) as usercount';
+		$query = $searcher->search($fields, $options);#
+
+		// the count with the subselect should be at the first
+		$this->assertEquals(0, strpos($query, 'SELECT COUNT(COUNTWRAP.uid) as cnt FROM'));
+		// check the uid where
+		$this->assertContains(' COUNT(FEUSER.uid) as usercount ', $query);
+		$this->assertContains(' FEUSER.uid = 54 ', $query);
+		$this->assertContains(' GROUP BY FEUSER.usergroup', $query);
+		// the closing subselect should be at the last
+		$this->assertEquals(
+			strlen($query) - strlen(') as COUNTWRAP WHERE 1=1'),
+			strpos($query, ') as COUNTWRAP WHERE 1=1')
+		);
+
+
+		// SELECT COUNT(FEUSER.uid) as usercount FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup HAVING usercount > 20
+		$options['having'] = 'usercount > 20';
+		$query = $searcher->search($fields, $options);#
+
+		// the count with the subselect should be at the first
+		$this->assertEquals(0, strpos($query, 'SELECT COUNT(COUNTWRAP.uid) as cnt FROM'));
+		// check the uid where
+		$this->assertContains(' COUNT(FEUSER.uid) as usercount ', $query);
+		$this->assertContains(' FEUSER.uid = 54 ', $query);
+		$this->assertContains(' GROUP BY FEUSER.usergroup ', $query);
+		$this->assertContains(' HAVING usercount > 20', $query);
+		// the closing subselect should be at the last
+		$this->assertEquals(
+			strlen($query) - strlen(') as COUNTWRAP WHERE 1=1'),
+			strpos($query, ') as COUNTWRAP WHERE 1=1')
+		);
+
+	}
+
+	public function getSearchForCountProvider() {
+		return array(
+			array(OP_LIKE, 'm', ' '), // warum müssen mindestens 3 buchstaben vorliegen?
+			array(OP_LIKE, 'm & m', ' '), // warum wird alles verschluckt? ist das richtig?
+			array(OP_LIKE, 'my m', " (Table1.col1 LIKE '%my%') "),
+			array(OP_LIKE, 'my', " (Table1.col1 LIKE '%my%') "),
+			array(OP_LIKE, 'myValue', " (Table1.col1 LIKE '%myValue%') "),
+			array(OP_LIKE, 'myValue test', " (Table1.col1 LIKE '%myValue%') AND  (Table1.col1 LIKE '%test%') "),
+			array(OP_LIKE_CONST, 'myValue test', " (Table1.col1 LIKE '%myValue test%') "),
+			array(OP_INSET_INT, '23', " (FIND_IN_SET('23', Table1.col1)) "),
+			array(OP_INSET_INT, '23,38', " (FIND_IN_SET('23', Table1.col1) OR FIND_IN_SET('38', Table1.col1)) "),
+		);
+	}
+
+
 	private function createOptions() {
 		$options = array();
 		$options['sqlonly'] = TRUE;
 		$options['searchdef']['basetable'] = 'fe_users';
-//		$options['searchdef']['usealias'] = TRUE;
-//		$options['searchdef']['basetablealias'] = 'FEUSER';
+		$options['searchdef']['usealias'] = TRUE;
+		$options['searchdef']['basetablealias'] = 'FEUSER';
 		$options['orderby']['username'] = 'asc';
-		
+
 		return $options;
 	}
+	/**
+	 *
+	 * @return tx_rnbase_util_SearchGeneric
+	 */
+	private function getGenericSearcher() {
+		return tx_rnbase::makeInstance('tx_rnbase_util_SearchGeneric');
+	}
+
 }
 
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_utilSearchBase_testcase.php']) {

--- a/tests/class.tx_rnbase_tests_util_SearchBase_testcase.php
+++ b/tests/class.tx_rnbase_tests_util_SearchBase_testcase.php
@@ -74,13 +74,13 @@ class tx_rnbase_tests_utilSearchBase_testcase extends tx_phpunit_testcase {
 
 
 		// SELECT COUNT(FEUSER.uid) FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup
-		$options['what'] = 'COUNT(FEUSER.uid) as usercount';
+		$options['what'] = 'FEUSER.*, COUNT(FEUSER.uid) as usercount';
 		$query = $searcher->search($fields, $options);#
 
 		// the count with the subselect should be at the first
 		$this->assertEquals(0, strpos($query, 'SELECT COUNT(COUNTWRAP.uid) as cnt FROM'));
 		// check the uid where
-		$this->assertContains(' COUNT(FEUSER.uid) as usercount ', $query);
+		$this->assertContains(' FEUSER.*, COUNT(FEUSER.uid) as usercount ', $query);
 		$this->assertContains(' FEUSER.uid = 54 ', $query);
 		$this->assertContains(' GROUP BY FEUSER.usergroup', $query);
 		// the closing subselect should be at the last
@@ -90,14 +90,14 @@ class tx_rnbase_tests_utilSearchBase_testcase extends tx_phpunit_testcase {
 		);
 
 
-		// SELECT COUNT(FEUSER.uid) as usercount FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup HAVING usercount > 20
+		// SELECT FEUSER.*, COUNT(FEUSER.uid) as usercount FROM fe_users AS FEUSER WHERE 1=1 AND FEUSER.uid = 54 GROUP BY FEUSER.usergroup HAVING usercount > 20
 		$options['having'] = 'usercount > 20';
 		$query = $searcher->search($fields, $options);#
 
 		// the count with the subselect should be at the first
 		$this->assertEquals(0, strpos($query, 'SELECT COUNT(COUNTWRAP.uid) as cnt FROM'));
 		// check the uid where
-		$this->assertContains(' COUNT(FEUSER.uid) as usercount ', $query);
+		$this->assertContains(' FEUSER.*,  COUNT(FEUSER.uid) as usercount ', $query);
 		$this->assertContains(' FEUSER.uid = 54 ', $query);
 		$this->assertContains(' GROUP BY FEUSER.usergroup ', $query);
 		$this->assertContains(' HAVING usercount > 20', $query);

--- a/util/class.tx_rnbase_util_SearchBase.php
+++ b/util/class.tx_rnbase_util_SearchBase.php
@@ -286,8 +286,8 @@ abstract class tx_rnbase_util_SearchBase {
 		) {
 			$sqlOptions['sqlonly'] = 1;
 			$query = tx_rnbase_util_DB::doSelect($what, $from, $sqlOptions, $options['debug'] ? 1 : 0);
-			$what = 'COUNT(COUNTWRAP.uid) as cnt';
-			$from = '(' . $query . ') as COUNTWRAP';
+			$what = 'COUNT(COUNTWRAP.uid) AS cnt';
+			$from = '(' . $query . ') AS COUNTWRAP';
 			$sqlOptions = array(
 				'enablefieldsoff' => TRUE,
 				'sqlonly' => empty($options['sqlonly']) ? 0 : $options['sqlonly'],


### PR DESCRIPTION
Bisher ist es über die Option `count` nicht möglich gewesen, die Anzahl der Datansätze zu ermitteln, wenn die Optionen `groupby` oder `having` gesetzt wurden.
Auch funktioniert das ganze nicht mehr, wenn über die Optionen ein eigenes `what` gesetzt wurde, wleches bereits einen COUNT enthält.

Bisher wurde die Option `count` einfach ignoriert, womit es zu PHP-Fehlern und Fehlverhalten des Programms kommt.

Das ganze lässt sich allerdings vermeiden, indem die eigentliche Query in ein Subselect gepackt, und der COUNT un den Wrap gesetzt wird.

Beispielquery, um die Anzahl an Nutzern zu ermitteln, welche den einzelnen Nutzergruppen zugewiesen Sind, dabei aber nur Gruppen ausgeben, die mehr als 20 Nutzer enthalten (nicht auf die Sinnhaftigkeit schauen):

```sql
SELECT FEUSER.*, COUNT(FEUSER.uid) as usercount
FROM fe_users AS FEUSER
WHERE FEUSER.uid > 0
GROUP BY FEUSER.usergroup
HAVING usercount > 20
```

Mit dem aktuellem Searcher und der zusätzlichen Option `count`, wird genau das selbe Statement gebildet, das unter umständen große Item-Array gebaut und dann lediglich `$result[0]['cnt']` zurückgegeben, was schief geht.

Mit den Änderungen aus diesem Branch wird die option `count` nicht mehr ignoriert, und die Query in einem Subselect abgesendet, wleches wiefolgt aussieht:
```sql
SELECT COUNT(COUNTWRAP.uid) AS cnt
FROM (
	SELECT FEUSER.*, COUNT(FEUSER.uid) as usercount
	FROM fe_users AS FEUSER
	WHERE FEUSER.uid > 0
	GROUP BY FEUSER.usergroup
	HAVING usercount > 20
) AS COUNTWRAP
```

@digedag, @hannesbochmann, @christianriesche:
Da dies eine Änderung im Basis-Searcher ist und ggf. gravierende Auswirkungen auf bisherigen Code in rn_base und den Extensions, wleche darauf aufbauen, haben könnte,
bitte ich um ein Code-Review!