### PR TITLE
Media Bugfix

### DIFF
--- a/model/class.tx_rnbase_model_media.php
+++ b/model/class.tx_rnbase_model_media.php
@@ -49,9 +49,13 @@ class tx_rnbase_model_media extends tx_rnbase_model_base {
 		// Ab TYPO3 6.x wird nur noch FAL unterstützt.
 		if(tx_rnbase_util_TYPO3::isTYPO60OrHigher()) {
 			// Bei FAL steckt in Media eine Referenz
-			$this->record = array_merge(
+			// die Referenzeigenschaften überschreiben die Eigenschaften
+			// der Originaldatei. Aber nur wenn diese nicht leer sind.
+			$notAddKeys = 0;
+			$includeEmptyValues = FALSE;
+			$this->record = t3lib_div::array_merge_recursive_overrule(
 				$media->getOriginalFile()->getProperties(),
-				$media->getReferenceProperties()
+				$media->getReferenceProperties(), $notAddKeys, $includeEmptyValues
 			);
 			// Wir verwenden hier die UID der Referenz
 			$this->uid = $media->getUid();

--- a/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
@@ -1,0 +1,87 @@
+<?php
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2011 Rene Nitzsche (rene@system25.de)
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+require_once(t3lib_extMgm::extPath('rn_base') . 'class.tx_rnbase.php');
+tx_rnbase::load('tx_rnbase_model_media');
+
+/**
+ *
+ * @author Hannes Bochmann <hannes.bochmann@dmk-business.de>
+ *
+ */
+class tx_rnbase_tests_model_Media_testcase extends tx_phpunit_testcase {
+
+	/**
+	 * @group unit
+	 */
+	public function testInitMediaForFalMediaMergesOriginalFileAndReferencePropertiesWithoutOverwritingWithEmptyValuesAndPreferingReferenceProperties() {
+		if (!tx_rnbase_util_TYPO3::isTYPO60OrHigher()) {
+			$this->markTestSkipped('Runs only in TYPO3 6.0 and higher');
+		}
+
+		$originalFile = $this->getMock(
+			'stdClass', array('getProperties')
+		);
+		$originalFile->expects($this->once())
+			->method('getProperties')
+			->will($this->returnValue(array(
+				'title' => 'sample picture',
+				'description' => 'this is a sample picture',
+				'otherField' => '/some/path'
+			)));
+		$falModel = $this->getMock(
+			'stdClass',
+			array('getOriginalFile', 'getReferenceProperties', 'getUid', 'getPublicUrl')
+		);
+		$falModel->expects($this->once())
+			->method('getReferenceProperties')
+			->will($this->returnValue(array(
+				'title' => 'sample picture reference',
+				'description' => '',
+				'otherField2' => '/some/other/path'
+			)));
+		$falModel->expects($this->once())
+			->method('getOriginalFile')
+			->will($this->returnValue($originalFile));
+
+		$mediaModel = tx_rnbase::makeInstance('tx_rnbase_model_media', $falModel);
+
+		$this->assertEquals(
+			'sample picture reference', $mediaModel->record['title'],
+			'not the title of the reference'
+		);
+		$this->assertEquals(
+			'/some/path', $mediaModel->record['otherField'],
+			'not the otherField of the original'
+		);
+		$this->assertEquals(
+			'/some/other/path', $mediaModel->record['otherField2'],
+			'not the otherField2 of the otherField2'
+		);
+		$this->assertEquals(
+			'this is a sample picture', $mediaModel->record['description'],
+			'not the description of the original'
+		);
+	}
+}


### PR DESCRIPTION
die Referenzeigenschaften überschreiben die Eigenschaften der Originaldatei. Aber nur wenn diese nicht leer sind.