### PR TITLE
load http utility class and fixed bug in TYPO3 4.5

### DIFF
--- a/util/class.tx_rnbase_util_TYPO3.php
+++ b/util/class.tx_rnbase_util_TYPO3.php
@@ -239,8 +239,10 @@ class tx_rnbase_util_TYPO3 {
 		if (self::isTYPO62OrHigher()) {
 			$httpUtilityClass = 'TYPO3\\CMS\\Core\\Utility\\HttpUtility';
 		} else {
-			$httpUtilityClass = \t3lib_utility_Http;
+			$httpUtilityClass = t3lib_utility_Http;
 		}
+		tx_rnbase::load($httpUtilityClass);
+
 		return $httpUtilityClass;
 	}
 }


### PR DESCRIPTION
Da fehlte noch das load um sicher zu gehen. In TYPO3 4.5 gab es auch noch einen Bug.