### PR TITLE
[TASK] Require TYPO3 CMS >= 6.2 and PHP >= 5.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
 		"typo3-ter/rn-base": "*"
 	},
 	"require" : {
-		"typo3/cms-core" : ">=4.3.0 <=6.2.99"
+		"typo3/cms-core" : ">=6.2.0 <=6.2.99"
 	}
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,8 +35,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'constraints' => array(
 		'depends' => array(
 			'cms' => '',
-			'typo3' => '4.3.0-6.2.99',
-			'php' => '5.0.0-0.0.0',
+			'typo3' => '6.2.0-6.2.99',
+			'php' => '5.3.7-5.6.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
PHP 5.3.7 is the required minimum version for TYPO3 CMS 6.2.