### PR TITLE
array acces for data model

### DIFF
--- a/model/class.tx_rnbase_model_data.php
+++ b/model/class.tx_rnbase_model_data.php
@@ -38,7 +38,7 @@ tx_rnbase::load('tx_rnbase_util_Misc');
  * @author Michael Wagner <michael.wagner@dmk-ebusiness.de>
  */
 class tx_rnbase_model_data
-	implements IteratorAggregate {
+	implements IteratorAggregate, ArrayAccess {
 
 	/**
 	 * A flag indication if the model was modified after initialisation
@@ -246,6 +246,79 @@ class tx_rnbase_model_data
 
 		return NULL;
 	}
+
+
+	/**
+	 * Attribute getter (deprecated)
+	 *
+	 * @param string $var
+	 * @return mixed
+	 */
+
+	public function __get($var)
+	{
+		$var = $this->underscore($var);
+		return $this->getProperty($var);
+	}
+
+	/**
+	 * Attribute setter (deprecated)
+	 *
+	 * @param string $var
+	 * @param mixed $value
+	 */
+	public function __set($var, $value)
+	{
+		$var = $this->underscore($var);
+		$this->setProperty($var, $value);
+	}
+
+    /**
+     * Implementation of ArrayAccess::offsetSet()
+     *
+     * @link http://www.php.net/manual/en/arrayaccess.offsetset.php
+     * @param string $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->record[$offset] = $value;
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetExists()
+     *
+     * @link http://www.php.net/manual/en/arrayaccess.offsetexists.php
+     * @param string $offset
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->record[$offset]);
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetUnset()
+     *
+     * @link http://www.php.net/manual/en/arrayaccess.offsetunset.php
+     * @param string $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->record[$offset]);
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetGet()
+     *
+     * @link http://www.php.net/manual/en/arrayaccess.offsetget.php
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->record[$offset]) ? $this->record[$offset] : NULL;
+    }
 
 	/**
 	 * Implementation of IteratorAggregate::getIterator()

--- a/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
@@ -78,6 +78,17 @@ class tx_rnbase_tests_model_Data_testcase
 
 	/**
 	 * @test
+	 */
+	public function testArrayAccess() {
+		$model = $this->getModelInstance();
+
+		$this->assertSame(50, $model['uid']);
+		$this->assertSame('John', $model['first_name']);
+		$this->assertNull($model['column_does_not_exist']);
+	}
+
+	/**
+	 * @test
 	 * @expectedException Exception
 	 * @expectedExceptionCode 1406625817
 	 */


### PR DESCRIPTION
I am not shure, if we need that.

Actually some extensions put an options array into the data model. so the config can be read out object-oriented.

Classic option access:
```php
$options = array('is_enabled' => 1);
if (isset($options['is_enabled']) && $options['is_enabled']) {
	// do something, if enabled
}
```
The oop way:
```php
$options = tx_rnbase_model_data::getInstance(array('is_enabled' => 1));
if ($options->getIsEnabled()) {
	// do something, if enabled
}
```

For backward compatibility it can be usefull to access the oop option the classic way. Than the data model needs to implement the `ArrayAccess` Interface.