### PR TITLE
[!!!][TASK] Drop XCLASS snippet

### DIFF
--- a/Classes/Database/Connection.php
+++ b/Classes/Database/Connection.php
@@ -1118,7 +1118,3 @@ function tx_rnbase_util_DB_prependAlias(&$item, $key, $alias)
 {
     $item = $alias . '.' . $item;
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/Classes/Database/Connection.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/Classes/Database/Connection.php']);
-}

--- a/action/class.tx_rnbase_action_Base.php
+++ b/action/class.tx_rnbase_action_Base.php
@@ -56,7 +56,3 @@ class tx_rnbase_action_Base
         return $this->cObject;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_Base.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_Base.php']);
-}

--- a/action/class.tx_rnbase_action_BaseIOC.php
+++ b/action/class.tx_rnbase_action_BaseIOC.php
@@ -343,7 +343,3 @@ abstract class tx_rnbase_action_BaseIOC
         return $link;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_BaseIOC.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_BaseIOC.php']);
-}

--- a/action/class.tx_rnbase_action_CacheHandlerDefault.php
+++ b/action/class.tx_rnbase_action_CacheHandlerDefault.php
@@ -319,7 +319,3 @@ class tx_rnbase_action_CacheHandlerDefault implements tx_rnbase_action_ICacheHan
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_CacheHandlerDefault.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_CacheHandlerDefault.php']);
-}

--- a/action/class.tx_rnbase_action_CacheHandlerUser.php
+++ b/action/class.tx_rnbase_action_CacheHandlerUser.php
@@ -66,7 +66,3 @@ class tx_rnbase_action_CacheHandlerUser extends tx_rnbase_action_CacheHandlerDef
         return $keys;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_CacheHandlerUser.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_CacheHandlerUser.php']);
-}

--- a/action/class.tx_rnbase_action_ICacheHandler.php
+++ b/action/class.tx_rnbase_action_ICacheHandler.php
@@ -57,7 +57,3 @@ interface tx_rnbase_action_ICacheHandler
      */
     public function getOutput();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_ICacheHandler.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/action/class.tx_rnbase_action_ICacheHandler.php']);
-}

--- a/cache/class.tx_rnbase_cache_ICache.php
+++ b/cache/class.tx_rnbase_cache_ICache.php
@@ -55,7 +55,3 @@ interface tx_rnbase_cache_ICache
      */
     public function remove($key);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/cache/class.tx_rnbase_cache_ICache.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/cache/class.tx_rnbase_cache_ICache.php']);
-}

--- a/cache/class.tx_rnbase_cache_Manager.php
+++ b/cache/class.tx_rnbase_cache_Manager.php
@@ -111,7 +111,3 @@ class tx_rnbase_cache_Manager
         return tx_rnbase::makeInstance('tx_rnbase_cache_TYPO3Cache62', $name);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/cache/class.tx_rnbase_cache_Manager.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/cache/class.tx_rnbase_cache_Manager.php']);
-}

--- a/class.tx_rnbase.php
+++ b/class.tx_rnbase.php
@@ -401,7 +401,3 @@ class tx_rnbase
         return $key ? $key : false;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase.php']);
-}

--- a/class.tx_rnbase_configurations.php
+++ b/class.tx_rnbase_configurations.php
@@ -1180,7 +1180,3 @@ class tx_rnbase_configurations implements Tx_Rnbase_Configuration_ProcessorInter
         return $data;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_configurations.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_configurations.php']);
-}

--- a/class.tx_rnbase_controller.php
+++ b/class.tx_rnbase_controller.php
@@ -451,7 +451,3 @@ class tx_rnbase_controller
         return $parameters;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_controller.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_controller.php']);
-}

--- a/class.tx_rnbase_parameters.php
+++ b/class.tx_rnbase_parameters.php
@@ -219,7 +219,3 @@ class tx_rnbase_parameters extends ArrayObject implements tx_rnbase_IParameters
         return $utility::_POST($var);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_parameters.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/class.tx_rnbase_parameters.php']);
-}

--- a/exception/class.tx_rnbase_exception_Handler.php
+++ b/exception/class.tx_rnbase_exception_Handler.php
@@ -257,7 +257,3 @@ class tx_rnbase_exception_Handler implements tx_rnbase_exception_IHandler
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/exception/class.tx_rnbase_exception_Handler.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/exception/class.tx_rnbase_exception_Handler.php']);
-}

--- a/exception/class.tx_rnbase_exception_Skip.php
+++ b/exception/class.tx_rnbase_exception_Skip.php
@@ -34,7 +34,3 @@
 class tx_rnbase_exception_Skip extends Exception
 {
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/exception/class.tx_rnbase_exception_SkipAction.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/exception/class.tx_rnbase_exception_SkipAction.php']);
-}

--- a/filter/class.tx_rnbase_filter_BaseFilter.php
+++ b/filter/class.tx_rnbase_filter_BaseFilter.php
@@ -557,7 +557,3 @@ class tx_rnbase_filter_BaseFilter implements tx_rnbase_IFilter, tx_rnbase_IFilte
         return $data;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_BaseFilter.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_BaseFilter.php']);
-}

--- a/filter/class.tx_rnbase_filter_FilterItem.php
+++ b/filter/class.tx_rnbase_filter_FilterItem.php
@@ -75,7 +75,3 @@ class tx_rnbase_filter_FilterItem implements tx_rnbase_IFilterItem
         $this->record['value'] = $value;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_FilterItem.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_FilterItem.php']);
-}

--- a/filter/class.tx_rnbase_filter_FilterItemMarker.php
+++ b/filter/class.tx_rnbase_filter_FilterItemMarker.php
@@ -35,7 +35,3 @@ class tx_rnbase_filter_FilterItemMarker extends tx_rnbase_util_BaseMarker
         return $out;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_FilterItemMarker.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/filter/class.tx_rnbase_filter_FilterItemMarker.php']);
-}

--- a/maps/class.tx_rnbase_maps_BaseMap.php
+++ b/maps/class.tx_rnbase_maps_BaseMap.php
@@ -65,7 +65,3 @@ abstract class tx_rnbase_maps_BaseMap implements tx_rnbase_maps_IMap
         $this->setMapType($type);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_BaseMap.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_BaseMap.php']);
-}

--- a/maps/class.tx_rnbase_maps_Coord.php
+++ b/maps/class.tx_rnbase_maps_Coord.php
@@ -70,7 +70,3 @@ class tx_rnbase_maps_Coord implements tx_rnbase_maps_ICoord
         $this->longitude = $long;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Coord.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Coord.php']);
-}

--- a/maps/class.tx_rnbase_maps_DefaultMarker.php
+++ b/maps/class.tx_rnbase_maps_DefaultMarker.php
@@ -187,7 +187,3 @@ class tx_rnbase_maps_DefaultMarker implements tx_rnbase_maps_IMarker
         $this->maxZoom = $zoom;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_DefaultMarker.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_DefaultMarker.php']);
-}

--- a/maps/class.tx_rnbase_maps_Factory.php
+++ b/maps/class.tx_rnbase_maps_Factory.php
@@ -135,7 +135,3 @@ class tx_rnbase_maps_Factory
         return $map;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Factory.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Factory.php']);
-}

--- a/maps/class.tx_rnbase_maps_IControl.php
+++ b/maps/class.tx_rnbase_maps_IControl.php
@@ -34,7 +34,3 @@ interface tx_rnbase_maps_IControl
      */
     public function render();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IControl.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IControl.php']);
-}

--- a/maps/class.tx_rnbase_maps_ICoord.php
+++ b/maps/class.tx_rnbase_maps_ICoord.php
@@ -40,7 +40,3 @@ interface tx_rnbase_maps_ICoord
      */
     public function getLongitude();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_ICoord.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_ICoord.php']);
-}

--- a/maps/class.tx_rnbase_maps_IIcon.php
+++ b/maps/class.tx_rnbase_maps_IIcon.php
@@ -40,7 +40,3 @@ interface tx_rnbase_maps_IIcon
      */
     public function render();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IIcon.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IIcon.php']);
-}

--- a/maps/class.tx_rnbase_maps_ILocation.php
+++ b/maps/class.tx_rnbase_maps_ILocation.php
@@ -43,7 +43,3 @@ interface tx_rnbase_maps_ILocation extends tx_rnbase_maps_ICoord
     public function getZip();
     public function getCountryCode();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_ILocation.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_ILocation.php']);
-}

--- a/maps/class.tx_rnbase_maps_IMap.php
+++ b/maps/class.tx_rnbase_maps_IMap.php
@@ -71,7 +71,3 @@ interface tx_rnbase_maps_IMap
      */
     public function getPROVID();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IMap.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IMap.php']);
-}

--- a/maps/class.tx_rnbase_maps_IMarker.php
+++ b/maps/class.tx_rnbase_maps_IMarker.php
@@ -85,7 +85,3 @@ interface tx_rnbase_maps_IMarker
      */
     public function getZoomMax();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IMarker.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_IMarker.php']);
-}

--- a/maps/class.tx_rnbase_maps_POI.php
+++ b/maps/class.tx_rnbase_maps_POI.php
@@ -189,7 +189,3 @@ class tx_rnbase_maps_POI extends tx_rnbase_maps_Coord implements tx_rnbase_maps_
         return $this->description;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Coord.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Coord.php']);
-}

--- a/maps/class.tx_rnbase_maps_TypeRegistry.php
+++ b/maps/class.tx_rnbase_maps_TypeRegistry.php
@@ -79,7 +79,3 @@ class tx_rnbase_maps_TypeRegistry
         return self::$mapTypes;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_TypeRegistry.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_TypeRegistry.php']);
-}

--- a/maps/class.tx_rnbase_maps_Util.php
+++ b/maps/class.tx_rnbase_maps_Util.php
@@ -113,7 +113,3 @@ class tx_rnbase_maps_Util
         return $marker;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Util.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/class.tx_rnbase_maps_Util.php']);
-}

--- a/maps/google/class.tx_rnbase_maps_google_Control.php
+++ b/maps/google/class.tx_rnbase_maps_google_Control.php
@@ -43,7 +43,3 @@ class tx_rnbase_maps_google_Control implements tx_rnbase_maps_IControl
         return $this->type;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Control.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Control.php']);
-}

--- a/maps/google/class.tx_rnbase_maps_google_Icon.php
+++ b/maps/google/class.tx_rnbase_maps_google_Icon.php
@@ -114,7 +114,3 @@ class tx_rnbase_maps_google_Icon implements tx_rnbase_maps_IIcon
         return $ret;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Icon.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Icon.php']);
-}

--- a/maps/google/class.tx_rnbase_maps_google_Map.php
+++ b/maps/google/class.tx_rnbase_maps_google_Map.php
@@ -163,7 +163,3 @@ class tx_rnbase_maps_google_Map extends tx_rnbase_maps_BaseMap
         return $this->getWecMap()->mapName;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Map.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/maps/google/class.tx_rnbase_maps_google_Map.php']);
-}

--- a/misc/class.tx_rnbase_misc_EvalDate.php
+++ b/misc/class.tx_rnbase_misc_EvalDate.php
@@ -47,7 +47,3 @@ class tx_rnbase_misc_EvalDate
 		';
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/misc/class.tx_rnbase_misc_EvalDate.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/misc/class.tx_rnbase_misc_EvalDate.php']);
-}

--- a/mod/base/class.tx_rnbase_mod_base_Lister.php
+++ b/mod/base/class.tx_rnbase_mod_base_Lister.php
@@ -534,7 +534,3 @@ abstract class tx_rnbase_mod_base_Lister
         return tx_rnbase_mod_Util::showSelectorByArray($items, $selectedItem, 'showhidden', $marker, $options);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/base/class.tx_rnbase_mod_base_Lister.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/base/class.tx_rnbase_mod_base_Lister.php']);
-}

--- a/mod/class.tx_rnbase_mod_BaseModFunc.php
+++ b/mod/class.tx_rnbase_mod_BaseModFunc.php
@@ -103,7 +103,3 @@ abstract class tx_rnbase_mod_BaseModFunc implements tx_rnbase_mod_IModFunc
      */
     abstract protected function getFuncId();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModFunc.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModFunc.php']);
-}

--- a/mod/class.tx_rnbase_mod_ExtendedModFunc.php
+++ b/mod/class.tx_rnbase_mod_ExtendedModFunc.php
@@ -209,7 +209,3 @@ abstract class tx_rnbase_mod_ExtendedModFunc implements tx_rnbase_mod_IModFunc
         return '###LABEL_NO_SUBSELECTORITEMS_FOUND###';
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_ExtendedModFunc.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_ExtendedModFunc.php']);
-}

--- a/mod/class.tx_rnbase_mod_IDecorator.php
+++ b/mod/class.tx_rnbase_mod_IDecorator.php
@@ -44,7 +44,3 @@ interface tx_rnbase_mod_IDecorator
      */
     public function format($value, $colName, $record, tx_rnbase_model_base $item);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IDecorator.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IDecorator.php']);
-}

--- a/mod/class.tx_rnbase_mod_IModFunc.php
+++ b/mod/class.tx_rnbase_mod_IModFunc.php
@@ -36,7 +36,3 @@ interface tx_rnbase_mod_IModFunc
      */
     public function main();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModFunc.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModFunc.php']);
-}

--- a/mod/class.tx_rnbase_mod_IModHandler.php
+++ b/mod/class.tx_rnbase_mod_IModHandler.php
@@ -52,7 +52,3 @@ interface tx_rnbase_mod_IModHandler
      */
     public function showScreen($template, tx_rnbase_mod_IModule $mod, $options);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModHandler.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModHandler.php']);
-}

--- a/mod/class.tx_rnbase_mod_IModule.php
+++ b/mod/class.tx_rnbase_mod_IModule.php
@@ -75,7 +75,3 @@ interface tx_rnbase_mod_IModule
      */
     public function addMessage($message, $title = '', $severity = 0, $storeInSession = false);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModule.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_IModule.php']);
-}

--- a/mod/class.tx_rnbase_mod_Tables.php
+++ b/mod/class.tx_rnbase_mod_Tables.php
@@ -88,7 +88,3 @@ class tx_rnbase_mod_Tables
         return tx_rnbase::makeInstance('Tx_Rnbase_Backend_Utility_Tables');
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_Tables.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_Tables.php']);
-}

--- a/mod/class.tx_rnbase_mod_Util.php
+++ b/mod/class.tx_rnbase_mod_Util.php
@@ -111,7 +111,3 @@ class tx_rnbase_mod_Util
         return $selectedItem;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_Util.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/class.tx_rnbase_mod_Util.php']);
-}

--- a/mod/linker/class.tx_rnbase_mod_linker_LinkerInterface.php
+++ b/mod/linker/class.tx_rnbase_mod_linker_LinkerInterface.php
@@ -42,7 +42,3 @@ interface tx_rnbase_mod_linker_LinkerInterface
      */
     public function makeLink($item, $formTool, $currentPid, $options);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/linker/class.tx_rnbase_mod_LinkerInterface.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/linker/class.tx_rnbase_mod_LinkerInterface.php']);
-}

--- a/mod/linker/class.tx_rnbase_mod_linker_ShowDetails.php
+++ b/mod/linker/class.tx_rnbase_mod_linker_ShowDetails.php
@@ -55,7 +55,3 @@ class tx_rnbase_mod_linker_ShowDetails implements tx_rnbase_mod_linker_LinkerInt
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/linker/class.tx_rnbase_mod_LinkerInterface.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/mod/linker/class.tx_rnbase_mod_LinkerInterface.php']);
-}

--- a/model/class.tx_rnbase_model_base.php
+++ b/model/class.tx_rnbase_model_base.php
@@ -360,7 +360,3 @@ class tx_rnbase_model_base extends tx_rnbase_model_data implements Tx_Rnbase_Dom
         return $formatter->wrap($this->record[$columnName], $baseConfId . $colConfId);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_base.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_base.php']);
-}

--- a/model/class.tx_rnbase_model_data.php
+++ b/model/class.tx_rnbase_model_data.php
@@ -342,7 +342,3 @@ class tx_rnbase_model_data implements Tx_Rnbase_Domain_Model_DataInterface, Iter
         return $this->toString();
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_data.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_data.php']);
-}

--- a/model/class.tx_rnbase_model_media.php
+++ b/model/class.tx_rnbase_model_media.php
@@ -97,7 +97,3 @@ class tx_rnbase_model_media extends tx_rnbase_model_base
         return 'tx_dam';
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_media.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/model/class.tx_rnbase_model_media.php']);
-}

--- a/plot/class.tx_rnbase_plot_Builder.php
+++ b/plot/class.tx_rnbase_plot_Builder.php
@@ -1456,6 +1456,3 @@ class tx_rnbase_plot_Builder
         }
     }
 }
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_Builder.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_Builder.php']);
-}

--- a/plot/class.tx_rnbase_plot_DataProvider.php
+++ b/plot/class.tx_rnbase_plot_DataProvider.php
@@ -101,7 +101,3 @@ class tx_rnbase_plot_DataProvider implements tx_rnbase_plot_IDataProvider
         $this->dataSets[$plotId][] = $dataSet;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_DataProvider.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_DataProvider.php']);
-}

--- a/plot/class.tx_rnbase_plot_DataProviderTS.php
+++ b/plot/class.tx_rnbase_plot_DataProviderTS.php
@@ -168,7 +168,3 @@ class tx_rnbase_plot_DataProviderTS implements tx_rnbase_plot_IDataProvider
         return $objRandom;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_DataProviderTS.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_DataProviderTS.php']);
-}

--- a/plot/class.tx_rnbase_plot_IDataProvider.php
+++ b/plot/class.tx_rnbase_plot_IDataProvider.php
@@ -50,7 +50,3 @@ interface tx_rnbase_plot_IDataProvider
      */
     public function getChartTitle($confArr);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_IDataProvider.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/plot/class.tx_rnbase_plot_IDataProvider.php']);
-}

--- a/sv1/class.tx_rnbase_sv1_Base.php
+++ b/sv1/class.tx_rnbase_sv1_Base.php
@@ -320,7 +320,3 @@ abstract class tx_rnbase_sv1_Base extends Tx_Rnbase_Service_Base
         return $data;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/sv1/class.tx_rnbase_sv1_Base.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/sv1/class.tx_rnbase_sv1_Base.php']);
-}

--- a/sv1/class.tx_rnbase_sv1_MediaPlayer.php
+++ b/sv1/class.tx_rnbase_sv1_MediaPlayer.php
@@ -85,7 +85,3 @@ class tx_rnbase_sv1_MediaPlayer extends Tx_Rnbase_Service_Base
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/sv1/class.tx_rnbase_sv1_MediaPlayer.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/sv1/class.tx_rnbase_sv1_MediaPlayer.php']);
-}

--- a/tests/Classes/Database/ConnectionTest.php
+++ b/tests/Classes/Database/ConnectionTest.php
@@ -280,7 +280,3 @@ class Tx_Rnbase_Database_ConnectionTest extends tx_rnbase_tests_BaseTestCase
         return tx_rnbase_util_Strings::debugString($str);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_DB_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_DB_testcase.php']);
-}

--- a/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
@@ -419,7 +419,3 @@ class tx_rnbase_tests_action_CacheHandlerDefault_testcase extends tx_rnbase_test
         return $handler;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_Logger_testcase.php
+++ b/tests/class.tx_rnbase_tests_Logger_testcase.php
@@ -62,7 +62,3 @@ class tx_rnbase_tests_Logger_testcase extends Tx_Phpunit_TestCase
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_Logger_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_Logger_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_basemarker_testcase.php
+++ b/tests/class.tx_rnbase_tests_basemarker_testcase.php
@@ -42,7 +42,3 @@ Das Spielergebnis:
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_basemarker_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_basemarker_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_cache_testcase.php
+++ b/tests/class.tx_rnbase_tests_cache_testcase.php
@@ -55,7 +55,3 @@ class tx_rnbase_tests_cache_testcase extends Tx_Phpunit_TestCase
         return tx_rnbase::makeInstance('tx_rnbase_cache_TYPO3Cache62', $name);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_cache_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_cache_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_calendar_testcase.php
+++ b/tests/class.tx_rnbase_tests_calendar_testcase.php
@@ -48,7 +48,3 @@ class tx_rnbase_tests_calendar_testcase extends Tx_Phpunit_TestCase
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_calendar_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_calendar_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_configurations_testcase.php
+++ b/tests/class.tx_rnbase_tests_configurations_testcase.php
@@ -132,7 +132,3 @@ class tx_rnbase_templateDummy
 {
     public $setup;
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnabse_tests_configurations_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnabse_tests_configurations_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_listbuilder_testcase.php
+++ b/tests/class.tx_rnbase_tests_listbuilder_testcase.php
@@ -267,7 +267,3 @@ No pics found!
 </html>
 ';
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_listbuilder_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_listbuilder_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_misc_testcase.php
+++ b/tests/class.tx_rnbase_tests_misc_testcase.php
@@ -73,7 +73,3 @@ class tx_rnbase_tests_misc_testcase extends Tx_Phpunit_TestCase
         $this->assertContains('getSubDontRemove', $html, '"getSubDontRemove" Params removed!');
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_misc_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_misc_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_parameters_testcase.php
+++ b/tests/class.tx_rnbase_tests_parameters_testcase.php
@@ -75,7 +75,3 @@ class tx_rnbase_tests_parameters_testcase extends Tx_Phpunit_TestCase
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_parameters_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_parameters_testcase.php']);
-}

--- a/tests/class.tx_rnbase_tests_rnbase_testcase.php
+++ b/tests/class.tx_rnbase_tests_rnbase_testcase.php
@@ -55,7 +55,3 @@ class tx_rnbase_tests_rnbase_testcase extends Tx_Phpunit_TestCase
             tx_rnbase_util_TYPO3::isExtMinVersion('t3sponsors', 2001);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_rnbase_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_rnbase_testcase.php']);
-}

--- a/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
+++ b/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
@@ -418,7 +418,3 @@ class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php']);
-}

--- a/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
+++ b/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
@@ -103,7 +103,3 @@ class tx_rnbase_tests_mod_linker_ShowDetails_testcase extends tx_rnbase_tests_Ba
     }
 }
 
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php']);
-}

--- a/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
@@ -196,7 +196,3 @@ class tx_rnbase_tests_model_Base_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertSame('1433161484', $model->getLastModifyDateTime()->format('U'));
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/model/class.tx_rnbase_tests_model_Base_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/model/class.tx_rnbase_tests_model_Base_testcase.php']);
-}

--- a/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
@@ -172,7 +172,3 @@ class tx_rnbase_tests_model_Data_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertSame('Jonas', $model->record['first_name']);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/model/class.tx_rnbase_tests_model_Data_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/model/class.tx_rnbase_tests_model_Data_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
@@ -95,7 +95,3 @@ class tx_rnbase_tests_util_Dates_testcase extends Tx_Phpunit_TestCase
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_Link_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Link_testcase.php
@@ -307,7 +307,3 @@ class tx_rnbase_tests_util_Link_testcase extends tx_rnbase_tests_BaseTestCase
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
@@ -97,7 +97,3 @@ class tx_rnbase_tests_util_Lock_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertFalse($lock->isLocked(), 'Process was not unlocked after the lifetime.');
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
@@ -247,7 +247,3 @@ class HttpUtility_Dummy
 {
     const HTTP_STATUS_404 = 404;
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
@@ -280,7 +280,3 @@ class tx_rnbase_tests_util_SearchBase_testcase extends Tx_Phpunit_TestCase
         self::assertNotContains('CONTENT.pid >=0', $query, 'pid for CONTENT is present');
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_utilSearchBase_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_utilSearchBase_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
@@ -199,7 +199,3 @@ TS;
         return $formatter;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_SimpleMarker_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_SimpleMarker_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
@@ -99,7 +99,3 @@ class tx_rnbase_tests_util_Strings_testcase extends tx_rnbase_tests_BaseTestCase
         self::assertFalse(tx_rnbase_util_Strings::inList('1,2,3', '4'));
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_Strings_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_Strings_testcase.php']);
-}

--- a/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
@@ -172,7 +172,3 @@ class tx_rnbase_tests_util_Templates_testcase extends tx_rnbase_tests_BaseTestCa
 </html>
 ';
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_Templates_testcase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/tests/class.tx_rnbase_tests_util_Templates_testcase.php']);
-}

--- a/util/class.tx_rnbase_util_Arrays.php
+++ b/util/class.tx_rnbase_util_Arrays.php
@@ -171,7 +171,3 @@ class tx_rnbase_util_Arrays
         return$differenceArray;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Arrays.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Arrays.php']);
-}

--- a/util/class.tx_rnbase_util_BEPager.php
+++ b/util/class.tx_rnbase_util_BEPager.php
@@ -126,7 +126,3 @@ class tx_rnbase_util_BEPager
         return $this->id.'data';
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_BEPager.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_BEPager.php']);
-}

--- a/util/class.tx_rnbase_util_Calendar.php
+++ b/util/class.tx_rnbase_util_Calendar.php
@@ -140,7 +140,3 @@ class tx_rnbase_util_Calendar
         return $this->_seconds[$field];
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Calendar.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Calendar.php']);
-}

--- a/util/class.tx_rnbase_util_DB.php
+++ b/util/class.tx_rnbase_util_DB.php
@@ -52,7 +52,3 @@ class tx_rnbase_util_DB
         return call_user_func_array(array($databaseUtility, $name), $arguments);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_DB.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_DB.php']);
-}

--- a/util/class.tx_rnbase_util_Dates.php
+++ b/util/class.tx_rnbase_util_Dates.php
@@ -307,7 +307,3 @@ class tx_rnbase_util_Dates
         return new DateTime($date, $timezone);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Dates.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Dates.php']);
-}

--- a/util/class.tx_rnbase_util_Debug.php
+++ b/util/class.tx_rnbase_util_Debug.php
@@ -217,7 +217,3 @@ class tx_rnbase_util_Debug
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Debug.php']) {
-    include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Debug.php']);
-}

--- a/util/class.tx_rnbase_util_Exception.php
+++ b/util/class.tx_rnbase_util_Exception.php
@@ -64,7 +64,3 @@ class tx_rnbase_util_Exception extends Exception
         return is_array($additional) && $asString ? print_r($additional, true) : $additional;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Exception.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Exception.php']);
-}

--- a/util/class.tx_rnbase_util_Files.php
+++ b/util/class.tx_rnbase_util_Files.php
@@ -334,7 +334,3 @@ class tx_rnbase_util_Files
         return $utility::isAllowedAbsPath($path);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Files.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Files.php']);
-}

--- a/util/class.tx_rnbase_util_FormTool.php
+++ b/util/class.tx_rnbase_util_FormTool.php
@@ -35,7 +35,3 @@ class tx_rnbase_util_FormTool extends Tx_Rnbase_Backend_Form_ToolBox
         parent::init($doc, $module);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormTool.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormTool.php']);
-}

--- a/util/class.tx_rnbase_util_FormUtil.php
+++ b/util/class.tx_rnbase_util_FormUtil.php
@@ -92,7 +92,3 @@ class tx_rnbase_util_FormUtil
         return $sysHidden;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormUtil.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormUtil.php']);
-}

--- a/util/class.tx_rnbase_util_FormatUtil.php
+++ b/util/class.tx_rnbase_util_FormatUtil.php
@@ -389,7 +389,3 @@ class tx_rnbase_util_FormatUtil
         return $markerArray;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormatUtil.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_FormatUtil.php']);
-}

--- a/util/class.tx_rnbase_util_IListProvider.php
+++ b/util/class.tx_rnbase_util_IListProvider.php
@@ -29,7 +29,3 @@ interface tx_rnbase_util_IListProvider
 {
     public function iterateAll($callback);
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_IListProvider.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_IListProvider.php']);
-}

--- a/util/class.tx_rnbase_util_Json.php
+++ b/util/class.tx_rnbase_util_Json.php
@@ -721,7 +721,3 @@ if (class_exists('PEAR_Error')) {
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Json.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Json.php']);
-}

--- a/util/class.tx_rnbase_util_Lang.php
+++ b/util/class.tx_rnbase_util_Lang.php
@@ -358,7 +358,3 @@ class tx_rnbase_util_Lang
         return $lang->sL($key);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Lang.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Lang.php']);
-}

--- a/util/class.tx_rnbase_util_Link.php
+++ b/util/class.tx_rnbase_util_Link.php
@@ -793,7 +793,3 @@ class tx_rnbase_util_Link
         return $utility::linkThisScript($getParams);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Link.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Link.php']);
-}

--- a/util/class.tx_rnbase_util_ListBuilderInfo.php
+++ b/util/class.tx_rnbase_util_ListBuilderInfo.php
@@ -65,7 +65,3 @@ class tx_rnbase_util_ListBuilderInfo implements ListBuilderInfo
         return null;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListBuilderInfo.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListBuilderInfo.php']);
-}

--- a/util/class.tx_rnbase_util_ListMarker.php
+++ b/util/class.tx_rnbase_util_ListMarker.php
@@ -193,7 +193,3 @@ class tx_rnbase_util_ListMarker
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListMarker.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListMarker.php']);
-}

--- a/util/class.tx_rnbase_util_ListMarkerInfo.php
+++ b/util/class.tx_rnbase_util_ListMarkerInfo.php
@@ -46,7 +46,3 @@ class tx_rnbase_util_ListMarkerInfo implements ListMarkerInfo
         return $this->template;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListMarkerInfo.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListMarkerInfo.php']);
-}

--- a/util/class.tx_rnbase_util_ListProvider.php
+++ b/util/class.tx_rnbase_util_ListProvider.php
@@ -53,7 +53,3 @@ class tx_rnbase_util_ListProvider implements tx_rnbase_util_IListProvider
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListProvider.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_ListProvider.php']);
-}

--- a/util/class.tx_rnbase_util_Lock.php
+++ b/util/class.tx_rnbase_util_Lock.php
@@ -230,7 +230,3 @@ class tx_rnbase_util_Lock
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Lock.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Lock.php']);
-}

--- a/util/class.tx_rnbase_util_Logger.php
+++ b/util/class.tx_rnbase_util_Logger.php
@@ -166,7 +166,3 @@ class tx_rnbase_util_Logger
         $utility::devLog($msg, $extKey, $severity, $dataVar);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Logger.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Logger.php']);
-}

--- a/util/class.tx_rnbase_util_Mail.php
+++ b/util/class.tx_rnbase_util_Mail.php
@@ -119,7 +119,3 @@ class tx_rnbase_util_Mail
         $mail->send();
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Mail.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Mail.php']);
-}

--- a/util/class.tx_rnbase_util_Math.php
+++ b/util/class.tx_rnbase_util_Math.php
@@ -65,7 +65,3 @@ class tx_rnbase_util_Math
         return MathUtility::forceIntegerInRange($theInt, $min, $max, $zeroValue);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Math.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Math.php']);
-}

--- a/util/class.tx_rnbase_util_Misc.php
+++ b/util/class.tx_rnbase_util_Misc.php
@@ -806,7 +806,3 @@ MAYDAYPAGE;
         $flashMessageService->getMessageQueueByIdentifier()->enqueue($flashMessage);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Misc.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Misc.php']);
-}

--- a/util/class.tx_rnbase_util_Network.php
+++ b/util/class.tx_rnbase_util_Network.php
@@ -131,7 +131,3 @@ class tx_rnbase_util_Network
         return self::cmpIP($remoteAddress, $devIPmask);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Network.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Network.php']);
-}

--- a/util/class.tx_rnbase_util_PageBrowser.php
+++ b/util/class.tx_rnbase_util_PageBrowser.php
@@ -252,7 +252,3 @@ interface PageBrowserMarker
     public function setPageBrowser($pb);
     public function parseTemplate($template, &$formatter, $pbConfId, $pbMarker = 'PAGEBROWSER');
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_PageBrowser.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_PageBrowser.php']);
-}

--- a/util/class.tx_rnbase_util_PageBrowserMarker.php
+++ b/util/class.tx_rnbase_util_PageBrowserMarker.php
@@ -280,7 +280,3 @@ class tx_rnbase_util_PageBrowserMarker implements PageBrowserMarker
         $this->noLink = array('', '');
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_PageBrowserMarker.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_PageBrowserMarker.php']);
-}

--- a/util/class.tx_rnbase_util_Queue.php
+++ b/util/class.tx_rnbase_util_Queue.php
@@ -118,7 +118,3 @@ class tx_rnbase_util_Queue
         $this->intEnd         = $this->intArraySize - 1;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Queue.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Queue.php']);
-}

--- a/util/class.tx_rnbase_util_SearchBase.php
+++ b/util/class.tx_rnbase_util_SearchBase.php
@@ -768,7 +768,3 @@ abstract class tx_rnbase_util_SearchBase
         return $specials;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/search/class.tx_rnbase_util_SearchBase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/search/class.tx_rnbase_util_SearchBase.php']);
-}

--- a/util/class.tx_rnbase_util_SearchGeneric.php
+++ b/util/class.tx_rnbase_util_SearchGeneric.php
@@ -68,7 +68,3 @@ class tx_rnbase_util_SearchGeneric extends tx_rnbase_util_SearchBase
         return $join;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_SearchGeneric.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_SearchGeneric.php']);
-}

--- a/util/class.tx_rnbase_util_SimpleMarker.php
+++ b/util/class.tx_rnbase_util_SimpleMarker.php
@@ -320,8 +320,3 @@ class tx_rnbase_util_SimpleMarker extends tx_rnbase_util_BaseMarker
         $this->classname = $name;
     }
 }
-
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_SimpleMarker.php']) {
-    include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_SimpleMarker.php']);
-}

--- a/util/class.tx_rnbase_util_Spyc.php
+++ b/util/class.tx_rnbase_util_Spyc.php
@@ -868,7 +868,3 @@ class tx_rnbase_util_Spyc
         return $line;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Spyc.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Spyc.php']);
-}

--- a/util/class.tx_rnbase_util_Strings.php
+++ b/util/class.tx_rnbase_util_Strings.php
@@ -203,7 +203,3 @@ class tx_rnbase_util_Strings
         return Tx_Rnbase_Utility_Strings::validEmail($email);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Strings.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Strings.php']);
-}

--- a/util/class.tx_rnbase_util_TCA.php
+++ b/util/class.tx_rnbase_util_TCA.php
@@ -402,7 +402,3 @@ class tx_rnbase_util_TCA
         return $uid > 0 ? $uid : $rawData['uid'];
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rnbase/util/class.tx_rnbase_util_TCA.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rnbase/util/class.tx_rnbase_util_TCA.php']);
-}

--- a/util/class.tx_rnbase_util_TSDAM.php
+++ b/util/class.tx_rnbase_util_TSDAM.php
@@ -536,7 +536,3 @@ class tx_rnbase_util_TSDAM
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TSDAM.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TSDAM.php']);
-}

--- a/util/class.tx_rnbase_util_TSFAL.php
+++ b/util/class.tx_rnbase_util_TSFAL.php
@@ -765,7 +765,3 @@ class tx_rnbase_util_TSFAL
         return $fileObject;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TSDAM.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TSDAM.php']);
-}

--- a/util/class.tx_rnbase_util_TYPO3.php
+++ b/util/class.tx_rnbase_util_TYPO3.php
@@ -372,6 +372,3 @@ class tx_rnbase_util_TYPO3
         return $isCliMode;
     }
 }
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TYPO3.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_TYPO3.php']);
-}

--- a/util/class.tx_rnbase_util_Templates.php
+++ b/util/class.tx_rnbase_util_Templates.php
@@ -475,7 +475,3 @@ class tx_rnbase_util_Templates
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Templates.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_Templates.php']);
-}

--- a/util/class.tx_rnbase_util_Wizicon.php
+++ b/util/class.tx_rnbase_util_Wizicon.php
@@ -75,7 +75,3 @@ abstract class tx_rnbase_util_Wizicon
         return $lang;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/cfc_league_fe/util/class.tx_cfcleaguefe_util_wizicon.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/cfc_league_fe/util/class.tx_cfcleaguefe_util_wizicon.php']);
-}

--- a/util/db/class.tx_rnbase_util_db_Exception.php
+++ b/util/db/class.tx_rnbase_util_db_Exception.php
@@ -29,7 +29,3 @@ tx_rnbase::load('tx_rnbase_util_Exception');
 class tx_rnbase_util_db_Exception extends tx_rnbase_util_Exception
 {
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_Exception.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_Exception.php']);
-}

--- a/util/db/class.tx_rnbase_util_db_IDatabase.php
+++ b/util/db/class.tx_rnbase_util_db_IDatabase.php
@@ -153,7 +153,3 @@ interface tx_rnbase_util_db_IDatabase
      */
     public function sql_error();
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_IDatabase.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_IDatabase.php']);
-}

--- a/util/db/class.tx_rnbase_util_db_MsSQL.php
+++ b/util/db/class.tx_rnbase_util_db_MsSQL.php
@@ -468,7 +468,3 @@ class tx_rnbase_util_db_MsSQL implements tx_rnbase_util_db_IDatabase
         return mssql_get_last_message();
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/db/class.tx_rnbase_util_db_MsSQL.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/db/class.tx_rnbase_util_db_MsSQL.php']);
-}

--- a/util/db/class.tx_rnbase_util_db_MySQL.php
+++ b/util/db/class.tx_rnbase_util_db_MySQL.php
@@ -379,7 +379,3 @@ class tx_rnbase_util_db_MySQL implements tx_rnbase_util_db_IDatabase
         return $this->db->error;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/db/class.tx_rnbase_util_db_MySQL.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/db/class.tx_rnbase_util_db_MySQL.php']);
-}

--- a/util/db/class.tx_rnbase_util_db_TYPO3.php
+++ b/util/db/class.tx_rnbase_util_db_TYPO3.php
@@ -157,7 +157,3 @@ class tx_rnbase_util_db_TYPO3
         return $GLOBALS['TYPO3_DB']->sql_free_result($res);
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_TYPO3.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/util/class.tx_rnbase_util_db_TYPO3.php']);
-}

--- a/view/class.tx_rnbase_view_Base.php
+++ b/view/class.tx_rnbase_view_Base.php
@@ -265,7 +265,3 @@ class tx_rnbase_view_Base
         return $path;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_Base.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_Base.php']);
-}

--- a/view/class.tx_rnbase_view_Single.php
+++ b/view/class.tx_rnbase_view_Single.php
@@ -48,7 +48,3 @@ class tx_rnbase_view_Single extends tx_rnbase_view_List
         return $out;
     }
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_Single.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_Single.php']);
-}

--- a/view/class.tx_rnbase_view_phpTemplateEngine.php
+++ b/view/class.tx_rnbase_view_phpTemplateEngine.php
@@ -75,6 +75,3 @@ class tx_rnbase_view_phpTemplateEngine extends tx_rnbase_view_Base
         return $out;
     }
 }
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_phpTemplateEngine.php']) {
-    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/rn_base/view/class.tx_rnbase_view_phpTemplateEngine.php']);
-}


### PR DESCRIPTION
This avoids PHP notices for the global $TYPO3_CONF_VARS variable which
is undefined in TYPO3 6.2 and up.

Fixes #55
