### PR TITLE
[CLEANUP] Rename all constructors to __construct

### DIFF
--- a/filter/class.tx_rnbase_filter_BaseFilter.php
+++ b/filter/class.tx_rnbase_filter_BaseFilter.php
@@ -66,7 +66,7 @@ class tx_rnbase_filter_BaseFilter implements tx_rnbase_IFilter, tx_rnbase_IFilte
 	private $confId;
 	protected $filterItems;
 
-	public function tx_rnbase_filter_BaseFilter(&$parameters, &$configurations, $confId) {
+	public function __construct(&$parameters, &$configurations, $confId) {
 		$this->configurations = $configurations;
 		$this->parameters = $parameters;
 		$this->confId = $confId;

--- a/filter/class.tx_rnbase_filter_FilterItem.php
+++ b/filter/class.tx_rnbase_filter_FilterItem.php
@@ -41,7 +41,7 @@ interface tx_rnbase_IFilterItem {
 
 class tx_rnbase_filter_FilterItem implements tx_rnbase_IFilterItem {
 	var $record;
-	function tx_rnbase_filter_FilterItem($name, $value) {
+	function __construct($name, $value) {
 		$this->record = array();
 		$this->setName($name);
 		$this->setValue($value);

--- a/maps/class.tx_rnbase_maps_TypeRegistry.php
+++ b/maps/class.tx_rnbase_maps_TypeRegistry.php
@@ -35,7 +35,7 @@ class tx_rnbase_maps_TypeRegistry {
 	static $instance = NULL;
 	private static $mapTypes = array(RNMAP_MAPTYPE_STREET, RNMAP_MAPTYPE_SATELLITE, RNMAP_MAPTYPE_HYBRID, RNMAP_MAPTYPE_PHYSICAL);
 	private $types = array();
-	private function tx_rnbase_maps_TypeRegistry() {
+	private function __construct() {
 	}
 	/**
 	 * Returns the singleton instance

--- a/maps/google/class.tx_rnbase_maps_google_Icon.php
+++ b/maps/google/class.tx_rnbase_maps_google_Icon.php
@@ -30,7 +30,7 @@ tx_rnbase::load('tx_rnbase_maps_IIcon');
 class tx_rnbase_maps_google_Icon implements tx_rnbase_maps_IIcon {
 	private $id = NULL;
 
-	function tx_rnbase_maps_google_Icon(tx_rnbase_maps_google_Map $map) {
+	function __construct(tx_rnbase_maps_google_Map $map) {
 		$this->map = $map;
 	}
 	function initFromTS($conf, $confId) {

--- a/model/class.tx_rnbase_model_base.php
+++ b/model/class.tx_rnbase_model_base.php
@@ -52,7 +52,7 @@ class tx_rnbase_model_base
 	 */
 	private $tableName = 0;
 
-	function tx_rnbase_model_base($rowOrUid = NULL) {
+	function __construct($rowOrUid = NULL) {
 		return $this->init($rowOrUid);
 	}
 

--- a/model/class.tx_rnbase_model_media.php
+++ b/model/class.tx_rnbase_model_media.php
@@ -34,7 +34,7 @@ class tx_rnbase_model_media extends tx_rnbase_model_base {
 
 	/**
 	 */
-	function tx_rnbase_model_media($rowOrUid) {
+	function __construct($rowOrUid) {
 		if(is_object($rowOrUid)) {
 			// Das Media-Objekt auslesen
 			$this->initMedia($rowOrUid);

--- a/tests/class.tx_rnbase_tests_configurations_testcase.php
+++ b/tests/class.tx_rnbase_tests_configurations_testcase.php
@@ -119,7 +119,7 @@ class tx_rnbase_tests_configurations_testcase extends Tx_Phpunit_TestCase {
 
 class tx_rnbase_tsfeDummy {
 	var $tmpl;
-	function tx_rnbase_tsfeDummy() {
+	function __construct() {
 		$this->tmpl = new tx_rnbase_templateDummy();
 	}
 }

--- a/util/class.tx_rnbase_util_Calendar.php
+++ b/util/class.tx_rnbase_util_Calendar.php
@@ -43,7 +43,7 @@ define('CALENDAR_DAY_OF_YEAR', 6);
 class tx_rnbase_util_Calendar {
   var $_time; // Die Zeit des Kalenders
 
-  function tx_rnbase_util_Calendar() {
+  function __construct() {
     $this->_time = time();
     $this->_init();
   }

--- a/util/class.tx_rnbase_util_FormatUtil.php
+++ b/util/class.tx_rnbase_util_FormatUtil.php
@@ -42,7 +42,7 @@ class tx_rnbase_util_FormatUtil {
    * Konstruktor
    * @param tx_rnbase_configurations $configurations
    */
-  function tx_rnbase_util_FormatUtil($configurations) {
+  function __construct($configurations) {
     $this->configurations = $configurations;
     $this->cObj = $configurations->getCObj();
   }

--- a/util/class.tx_rnbase_util_ListMarkerInfo.php
+++ b/util/class.tx_rnbase_util_ListMarkerInfo.php
@@ -32,7 +32,7 @@ interface ListMarkerInfo {
  */
 class tx_rnbase_util_ListMarkerInfo implements ListMarkerInfo {
 
-  function tx_rnbase_util_ListMarkerInfo() {
+  function __construct() {
   }
   function init($template, &$formatter, $marker) {
   	$this->template = $template;

--- a/util/class.tx_rnbase_util_Queue.php
+++ b/util/class.tx_rnbase_util_Queue.php
@@ -43,7 +43,7 @@ class tx_rnbase_util_Queue {
   * Queue constructor
   * @param int $intQueue - size of queue
   */
-  function tx_rnbase_util_Queue( $intSize = QUEUE_DEFAULT_SIZE )
+  function __construct( $intSize = QUEUE_DEFAULT_SIZE )
   {
     $this->arrQueue     = Array();
     $this->intArraySize = $intSize;

--- a/view/class.tx_rnbase_view_phpTemplateEngine.php
+++ b/view/class.tx_rnbase_view_phpTemplateEngine.php
@@ -39,7 +39,7 @@ tx_rnbase::load('tx_rnbase_view_Base');
  */
 class tx_rnbase_view_phpTemplateEngine extends tx_rnbase_view_Base {
 
-  function tx_rnbase_view_phpTemplateEngine() {
+  function __construct() {
   }
 
   /**


### PR DESCRIPTION
Since PHP 5, constructors in PHP should be named __construct, not as
the class name anymore.
