### PR TITLE
- using MarkerBasedTemplateService with TYPO3 7 or Higher

### DIFF
--- a/util/class.tx_rnbase_util_Templates.php
+++ b/util/class.tx_rnbase_util_Templates.php
@@ -47,7 +47,7 @@ class tx_rnbase_util_Templates
      */
     public static function getSubpart($template, $subpart)
     {
-        if (tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
+        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
             $parser = tx_rnbase::makeInstance(
                 'TYPO3\\CMS\\Core\\Service\\MarkerBasedTemplateService'
             );
@@ -462,7 +462,7 @@ class tx_rnbase_util_Templates
      */
     public static function substituteSubpart($content, $marker, $subpartContent, $recursive = 1)
     {
-        if (tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
+        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
             $parser = tx_rnbase::makeInstance(
                 'TYPO3\\CMS\\Core\\Service\\MarkerBasedTemplateService'
             );


### PR DESCRIPTION
Hi,
the old class `TYPO3\CMS\Core\Html\HtmlParser` is deprecated in TYPO3 7.* and you schould use the `TYPO3\\CMS\\Core\\Service\\MarkerBasedTemplateService`.
So i changed the condition from minimum T3 8.* to T3 7.* ;)
