### PR TITLE
[TASK] Replace usage of the deprecated removeXSS method

### DIFF
--- a/Classes/Utility/Strings.php
+++ b/Classes/Utility/Strings.php
@@ -294,14 +294,15 @@ class Tx_Rnbase_Utility_Strings
     }
 
     /**
-     * Wrapper method for t3lib_div::removeXSS() or \TYPO3\CMS\Core\Utility\GeneralUtility::removeXSS()
+     * Makes the given string safe against XSS.
      *
      * @param string $string Input string
+     *
      * @return string Input string with potential XSS code removed
      */
     public static function removeXSS($string)
     {
-        return Tx_Rnbase_Utility_T3General::removeXSS($string);
+        return htmlspecialchars($string);
     }
 
     /**

--- a/class.tx_rnbase_parameters.php
+++ b/class.tx_rnbase_parameters.php
@@ -106,7 +106,7 @@ class tx_rnbase_parameters extends ArrayObject implements tx_rnbase_IParameters
         $value = $this->get($paramName, $qualifier);
         // remove Cross-Site Scripting
         if (!empty($value) && strlen($value) > 3) {
-            $value = tx_rnbase_util_Strings::removeXSS($value);
+            $value = htmlspecialchars($value);
         }
 
         return $value;

--- a/util/class.tx_rnbase_util_FormUtil.php
+++ b/util/class.tx_rnbase_util_FormUtil.php
@@ -84,8 +84,8 @@ class tx_rnbase_util_FormUtil
             $params = $utility::explodeUrl2Array($params);
         }
         foreach ($params as $name => $value) {
-            $name = htmlspecialchars(tx_rnbase_util_Strings::removeXSS($name), ENT_QUOTES);
-            $value = htmlspecialchars(tx_rnbase_util_Strings::removeXSS($value), ENT_QUOTES);
+            $name = htmlspecialchars($name);
+            $value = htmlspecialchars($value);
             $sysHidden .= '<input type="hidden" name="'.$name.'" value="'.$value.'" />';
         }
 

--- a/util/class.tx_rnbase_util_Strings.php
+++ b/util/class.tx_rnbase_util_Strings.php
@@ -167,14 +167,15 @@ class tx_rnbase_util_Strings
     }
 
     /**
-     * Wrapper method for t3lib_div::removeXSS() or \TYPO3\CMS\Core\Utility\GeneralUtility::removeXSS()
+     * Makes the given string safe against XSS.
      *
      * @param string $string Input string
+     *
      * @return string Input string with potential XSS code removed
      */
     public static function removeXSS($string)
     {
-        return Tx_Rnbase_Utility_Strings::removeXSS($string);
+        return htmlspecialchars($string);
     }
 
     /**


### PR DESCRIPTION
The corresponding Core method has been deprecated as it was not considered to
be really safe. htmlspecialchars should be used instead.