### PR TITLE
[BUGFIX] Fix deprecation warning in TYPO3 7.6 for `readLLfile`

### DIFF
--- a/util/class.tx_rnbase_util_Lang.php
+++ b/util/class.tx_rnbase_util_Lang.php
@@ -77,7 +77,7 @@ class tx_rnbase_util_Lang
         $errorMode = 0,
         $isLocalizationOverride = false
     ) {
-        if (tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
+        if (tx_rnbase_util_TYPO3::isTYPO74OrHigher()) {
             /** @var $languageFactory \TYPO3\CMS\Core\Localization\LocalizationFactory */
             $languageFactory = tx_rnbase::makeInstance(
                 'TYPO3\\CMS\\Core\\Localization\\LocalizationFactory'
@@ -90,11 +90,11 @@ class tx_rnbase_util_Lang
                 $errorMode,
                 $isLocalizationOverride
             );
-        } else {
-            $utility = tx_rnbase_util_Typo3Classes::getGeneralUtilityClass();
-
-            return $utility::readLLfile($fileReference, $languageKey, $charset);
         }
+
+        $utility = tx_rnbase_util_Typo3Classes::getGeneralUtilityClass();
+
+        return $utility::readLLfile($fileReference, $languageKey, $charset);
     }
 
 

--- a/util/class.tx_rnbase_util_TYPO3.php
+++ b/util/class.tx_rnbase_util_TYPO3.php
@@ -66,6 +66,17 @@ class tx_rnbase_util_TYPO3
     {
         return self::isTYPO3VersionOrHigher(7000000);
     }
+
+    /**
+     * Prüft, ob mindestens TYPO3 Version 7.4 vorhanden ist.
+     *
+     * @return bool
+     */
+    public static function isTYPO74OrHigher()
+    {
+        return self::isTYPO3VersionOrHigher(7004000);
+    }
+
     /**
      * Prüft, ob mindestens TYPO3 Version 7.6 vorhanden ist.
      *


### PR DESCRIPTION
`GeneralUtility::readLLfile` was deprecated in TYPO3 7.4, not in
version 8.0.

So now `tx_rnbase_util_Lang::readLLfile` will not create deprecation
warnings in TYPO3 7.6 anymore.