### PR TITLE
[TASK] change composer.json for TYPO3 subtree split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "digedag/rn-base": "self.version"
     },
     "require": {
-        "typo3/cms": ">=4.5.0 <=8.7.99",
+        "typo3/cms-core": "^7.6 || ^8.7",
         "php": ">=5.6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "digedag/rn-base": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.7",
+        "typo3/cms-core": "^6.2 || ^7.6 || ^8.7",
         "php": ">=5.6.0"
     },
     "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,7 +33,7 @@ $EM_CONF[$_EXTKEY] = array(
     'CGLcompliance_note' => '',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '4.5.0-8.7.99',
+            'typo3' => '6.2.0-8.7.99',
             'php' => '5.6.0-8.9.99'
         ),
         'conflicts' => array(


### PR DESCRIPTION
For `composer.json` one should require `typo3/cms-core` instead of `typo3/cms`due to the subtree split. In summary the main reason is extensions define a dependency on TYPO3 itself (core) instead of each and every system extension. Details: https://usetypo3.com/typo3-subtree-split-and-composer.html

However this needs to drop v6 support as well. This is one step for v9 compatibility, however even with v8 extensions requiring `typo3/cms` are a hassle to maintain.