### PR TITLE
[BUGFIX] Drop the use of undefined calendar constants

### DIFF
--- a/util/class.tx_rnbase_util_Calendar.php
+++ b/util/class.tx_rnbase_util_Calendar.php
@@ -123,8 +123,7 @@ class tx_rnbase_util_Calendar
                              CALENDAR_HOUR => 60 * 60,
                              CALENDAR_DAY_OF_MONTH => 86400,
                              CALENDAR_DAY_OF_YEAR => 86400,
-                             CALENDAR_WEEK_OF_MONTH => 86400 * 7,
-                             CALENDAR_WEEK_OF_YEAR => 86400 * 7 );
+        );
 
         $this->_clearHash = array( CALENDAR_SECOND => 'seconds',
                              CALENDAR_MINUTE => 'minutes',


### PR DESCRIPTION
These constants are not defined anywhere, and the values are not used anywhere.

This fixes an issue with PHP 7.2 as described in #117.