### PR TITLE
[TASK] Drop code for TYPO3 <= 7.6

### DIFF
--- a/Classes/Backend/Form/ToolBox.php
+++ b/Classes/Backend/Form/ToolBox.php
@@ -1,7 +1,5 @@
 <?php
 
-use Sys25\RnBase\Utility\Typo3Classes;
-
 /***************************************************************
 *  Copyright notice
 *
@@ -68,9 +66,7 @@ class Tx_Rnbase_Backend_Form_ToolBox
         $this->module = $module;
 
         // TCEform für das Formular erstellen
-        $this->form = tx_rnbase_util_TYPO3::isTYPO76OrHigher() ?
-            tx_rnbase::makeInstance('Tx_Rnbase_Backend_Form_FormBuilder') :
-            tx_rnbase::makeInstance(Typo3Classes::getBackendFormEngineClass());
+        $this->form = tx_rnbase::makeInstance('Tx_Rnbase_Backend_Form_FormBuilder');
         $this->form->initDefaultBEmode();
         $this->form->backPath = $BACK_PATH;
     }
@@ -370,21 +366,8 @@ class Tx_Rnbase_Backend_Form_ToolBox
     {
         $jsCode = $this->getJavaScriptForLinkToDataHandlerAction('cmd['.$table.']['.$uid.'][move]=-'.$moveId.'&prErr=1&uPT=1', $options);
         $label = isset($options['label']) ? $options['label'] : 'Move up';
-        $title = isset($options['title']) ? $options['title'] : $label;
 
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $image = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon('actions-move-up');
-        } else {
-            $image = sprintf(
-                '<img %s title="%s" alt="">',
-                Tx_Rnbase_Backend_Utility_Icons::skinImg(
-                    $GLOBALS['BACK_PATH'],
-                    'gfx/up.gif',
-                    'width="13" height="12"'
-                ),
-                $title
-            );
-        }
+        $image = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon('actions-move-up');
 
         return sprintf(
             '<a onclick="%1$s" href="#">%2$s%3$s</a>',
@@ -408,21 +391,8 @@ class Tx_Rnbase_Backend_Form_ToolBox
     {
         $jsCode = $this->getJavaScriptForLinkToDataHandlerAction('cmd['.$table.']['.$uid.'][move]=-'.$moveId, $options);
         $label = isset($options['label']) ? $options['label'] : 'Move up';
-        $title = isset($options['title']) ? $options['title'] : $label;
 
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $image = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon('actions-move-down');
-        } else {
-            $image = sprintf(
-                '<img %s title="%s" alt="">',
-                Tx_Rnbase_Backend_Utility_Icons::skinImg(
-                    $GLOBALS['BACK_PATH'],
-                    'gfx/up.gif',
-                    'width="13" height="12"'
-                ),
-                $title
-            );
-        }
+        $image = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon('actions-move-down');
 
         return sprintf(
             '<a onclick="%1$s" href="#">%2$s%3$s</a>',
@@ -896,20 +866,9 @@ class Tx_Rnbase_Backend_Form_ToolBox
         //noch den Pfeil für die aktuelle Sortierungsrichtung ggf. einblenden
         $sSortArrow = '';
         if ($sCurrentSortField == $sSortField) {
-            if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-                $sSortArrow = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon(
-                    'asc' == $sSortRev ? 'actions-move-up' : 'actions-move-down'
-                );
-            } else {
-                $sSortArrow = sprintf(
-                    '<img %s alt="">',
-                    Tx_Rnbase_Backend_Utility_Icons::skinImg(
-                        $GLOBALS['BACK_PATH'],
-                        'gfx/red'.('asc' == $sSortRev ? 'up' : 'down').'.gif',
-                        'width="7" height="4"'
-                    )
-                );
-            }
+            $sSortArrow = Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon(
+                'asc' == $sSortRev ? 'actions-move-up' : 'actions-move-down'
+            );
         }
 
         return '<a href="'.htmlspecialchars($sSortUrl).'">'.$sLabel.$sSortArrow.'</a>';
@@ -1107,8 +1066,7 @@ class Tx_Rnbase_Backend_Form_ToolBox
         if (is_array($MENU[$name]) && 1 == count($MENU[$name])) {
             $ret['menu'] = self::buildDummyMenu('SET['.$name.']', $MENU[$name]);
         } else {
-            $funcMenu = tx_rnbase_util_TYPO3::isTYPO76OrHigher() ? 'getDropdownMenu' : 'getFuncMenu';
-            $ret['menu'] = Tx_Rnbase_Backend_Utility::$funcMenu(
+            $ret['menu'] = Tx_Rnbase_Backend_Utility::getDropdownMenu(
                 $pid,
                 'SET['.$name.']',
                 $SETTINGS[$name],

--- a/Classes/Backend/Utility/Icons.php
+++ b/Classes/Backend/Utility/Icons.php
@@ -72,17 +72,7 @@ class Tx_Rnbase_Backend_Utility_Icons
         array $row,
         $size = 'default'
     ) {
-        if (tx_rnbase_util_TYPO3::isTYPO76OrHigher()) {
-            return static::getIconFactory()->getIconForRecord($table, $row, $size);
-        }
-
-        return static::__callStatic(
-            'getSpriteIconForRecord',
-            [
-                $table,
-                $row,
-            ]
-        );
+        return static::getIconFactory()->getIconForRecord($table, $row, $size);
     }
 
     /**

--- a/Classes/Backend/Utility/Tables.php
+++ b/Classes/Backend/Utility/Tables.php
@@ -111,25 +111,13 @@ class Tx_Rnbase_Backend_Utility_Tables
             if (!array_key_exists($record['uid'], $dontcheck)) {
                 $row[] = $formTool->createCheckbox($checkName.'[]', $record['uid']);
             } else {
-                if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-                    $row[] = sprintf(
-                        '<span title="Info: %s">%s</span>',
-                        $dontcheck[$record['uid']],
-                        Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon(
-                            'actions-document-info'
-                        )
-                    );
-                } else {
-                    $row[] = sprintf(
-                        '<img %s title="Info: %s" alt="">',
-                        Tx_Rnbase_Backend_Utility_Icons::skinImg(
-                            $GLOBALS['BACK_PATH'],
-                            'gfx/zoom2.gif',
-                            'width="1" height="12"'
-                        ),
-                        $dontcheck[$record['uid']]
-                    );
-                }
+                $row[] = sprintf(
+                    '<span title="Info: %s">%s</span>',
+                    $dontcheck[$record['uid']],
+                    Tx_Rnbase_Backend_Utility_Icons::getSpriteIcon(
+                        'actions-document-info'
+                    )
+                );
             }
         }
 
@@ -326,9 +314,7 @@ class Tx_Rnbase_Backend_Utility_Tables
             } else {
                 $result = $resultHead.$result;
             }
-            $tableTag = tx_rnbase_util_TYPO3::isTYPO76OrHigher() ?
-                '<table class="table table-striped table-hover table-condensed">' :
-                '<table border="0" cellspacing="0" cellpadding="0" class="typo3-dblist" id="typo3-tmpltable">';
+            $tableTag = '<table class="table table-striped table-hover table-condensed">';
             $tableWrap = is_array($tableLayout['table']) ? $tableLayout['table'] : [$tableTag, '</table>'];
             $result = $tableWrap[0].$result.$tableWrap[1];
         }
@@ -343,7 +329,7 @@ class Tx_Rnbase_Backend_Utility_Tables
      */
     public function getTableLayout()
     {
-        return tx_rnbase_util_TYPO3::isTYPO76OrHigher() ?
+        return
             [
                 'headRows' => [0],
                 'table' => ['<table class="table table-striped table-hover table-condensed">', '</table><br/>'],
@@ -361,23 +347,6 @@ class Tx_Rnbase_Backend_Utility_Tables
                         // Format für jede Spalte in jeder Zeile
                         'defCol' => ['<td>', '</td>'],
                         ],
-                ] :
-            [
-                'table' => ['<table class="typo3-dblist" width="100%" cellspacing="0" cellpadding="0" border="0">', '</table><br/>'],
-                '0' => [ // Format für 1. Zeile
-                        'tr' => ['<tr class="t3-row-header c-headLineTable">', '</tr>'],
-                        // Format für jede Spalte in der 1. Zeile
-                        'defCol' => ['<td>', '</td>'],
-                        ],
-                'defRow' => [ // Formate für alle Zeilen
-                        'tr' => ['<tr class="db_list_normal">', '</tr>'],
-                        'defCol' => ['<td>', '</td>'], // Format für jede Spalte in jeder Zeile
-                        ],
-                'defRowEven' => [ // Formate für alle geraden Zeilen
-                        'tr' => ['<tr class="db_list_alt">', '</tr>'],
-                        // Format für jede Spalte in jeder Zeile
-                        'defCol' => ['<td>', '</td>'],
-                        ],
-                ];
+            ];
     }
 }

--- a/Classes/Utility/Cache.php
+++ b/Classes/Utility/Cache.php
@@ -103,18 +103,10 @@ class Tx_Rnbase_Utility_Cache
      */
     public static function generateCacheHashForUrlQueryString($urlQueryString)
     {
-        if (tx_rnbase_util_TYPO3::isTYPO76OrHigher()) {
-            /* @var $calculator \TYPO3\CMS\Frontend\Page\CacheHashCalculator */
-            $calculator = tx_rnbase::makeInstance('TYPO3\\CMS\\Frontend\\Page\\CacheHashCalculator');
-            $hash = $calculator->generateForParameters($urlQueryString);
-        } elseif (class_exists('t3lib_cacheHash')) {
-            $calculator = new t3lib_cacheHash();
-            $hash = $calculator->generateForParameters($urlQueryString);
-        } elseif (is_callable([t3lib_div, 'generateCHash'])) {
-            $hash = t3lib_div::generateCHash($urlQueryString);
-        }
+        /* @var $calculator \TYPO3\CMS\Frontend\Page\CacheHashCalculator */
+        $calculator = tx_rnbase::makeInstance('TYPO3\\CMS\\Frontend\\Page\\CacheHashCalculator');
 
-        return $hash;
+        return $calculator->generateForParameters($urlQueryString);
     }
 
     /**

--- a/Classes/Utility/Misc.php
+++ b/Classes/Utility/Misc.php
@@ -357,17 +357,6 @@ MAYDAYPAGE;
             !($GLOBALS['TSFE'] instanceof $typoScriptFrontendControllerClass) ||
             $force
         ) {
-            if (!TYPO3::isTYPO70OrHigher() && !defined('PATH_tslib')) {
-                // PATH_tslib setzen
-                if (@is_dir(\Sys25\RnBase\Utility\Environment::getPublicPath().'typo3/sysext/cms/tslib/')) {
-                    define('PATH_tslib', \Sys25\RnBase\Utility\Environment::getPublicPath().'typo3/sysext/cms/tslib/');
-                } elseif (@is_dir(\Sys25\RnBase\Utility\Environment::getPublicPath().'tslib/')) {
-                    define('PATH_tslib', \Sys25\RnBase\Utility\Environment::getPublicPath().'tslib/');
-                } else {
-                    define('PATH_tslib', '');
-                }
-            }
-
             if (TYPO3::isTYPO90OrHigher()) {
                 $rootLine = null;
                 if ($pid > 0) {

--- a/Classes/Utility/Typo3Classes.php
+++ b/Classes/Utility/Typo3Classes.php
@@ -43,10 +43,7 @@ class Typo3Classes
      */
     public static function getFlashMessageClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_FlashMessage',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Messaging\\FlashMessage';
     }
 
     /**
@@ -54,10 +51,7 @@ class Typo3Classes
      */
     public static function getBackendFormEngineClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_tceforms',
-            self::HIGHER6 => 'TYPO3\\CMS\\Backend\\Form\\FormEngine',
-        ]);
+        return 'TYPO3\\CMS\\Backend\\Form\\FormEngine';
     }
 
     /**
@@ -65,10 +59,7 @@ class Typo3Classes
      */
     public static function getBasicFileUtilityClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_basicFileFunctions',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Utility\\File\\BasicFileUtility',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Utility\\File\\BasicFileUtility';
     }
 
     /**
@@ -76,10 +67,7 @@ class Typo3Classes
      */
     public static function getExtendedTypoScriptTemplateServiceClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_tsparser_ext',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService',
-        ]);
+        return 'TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService';
     }
 
     /**
@@ -87,10 +75,7 @@ class Typo3Classes
      */
     public static function getContentObjectRendererClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'tslib_cObj',
-            self::HIGHER6 => 'TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer',
-        ]);
+        return 'TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer';
     }
 
     /**
@@ -98,10 +83,7 @@ class Typo3Classes
      */
     public static function getTypoScriptFrontendControllerClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'tslib_fe',
-            self::HIGHER6 => 'TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController',
-        ]);
+        return 'TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController';
     }
 
     /**
@@ -109,10 +91,7 @@ class Typo3Classes
      */
     public static function getFrontendUserAuthenticationClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'tslib_feUserAuth',
-            self::HIGHER6 => 'TYPO3\\CMS\\Frontend\\Authentication\\FrontendUserAuthentication',
-        ]);
+        return 'TYPO3\\CMS\\Frontend\\Authentication\\FrontendUserAuthentication';
     }
 
     /**
@@ -120,10 +99,7 @@ class Typo3Classes
      */
     public static function getCharsetConverterClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_cs',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Charset\\CharsetConverter',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Charset\\CharsetConverter';
     }
 
     /**
@@ -131,10 +107,7 @@ class Typo3Classes
      */
     public static function getDataHandlerClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_tcemain',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\DataHandling\\DataHandler',
-        ]);
+        return 'TYPO3\\CMS\\Core\\DataHandling\\DataHandler';
     }
 
     /**
@@ -142,10 +115,7 @@ class Typo3Classes
      */
     public static function getSpriteManagerClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_SpriteManager',
-            self::HIGHER6 => 'TYPO3\\CMS\Backend\\Sprite\\SpriteManager',
-        ]);
+        return 'TYPO3\\CMS\Backend\\Sprite\\SpriteManager';
     }
 
     /**
@@ -178,17 +148,12 @@ class Typo3Classes
     public static function getTimeTrackClass()
     {
         $higher6Class = 'TYPO3\\CMS\\Core\\TimeTracker\\NullTimeTracker';
-        if (TYPO3::isTYPO62OrHigher()) {
-            $beCookie = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
-            if ($_COOKIE[$beCookie]) {
-                $higher6Class = 'TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker';
-            }
+        $beCookie = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
+        if ($_COOKIE[$beCookie]) {
+            $higher6Class = 'TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker';
         }
 
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_timeTrack',
-            self::HIGHER6 => $higher6Class,
-        ]);
+        return $higher6Class;
     }
 
     /**
@@ -196,10 +161,7 @@ class Typo3Classes
      */
     public static function getCommandUtilityClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_exec',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Utility\\CommandUtility',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Utility\\CommandUtility';
     }
 
     /**
@@ -207,10 +169,7 @@ class Typo3Classes
      */
     public static function getMailMessageClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_mail_Message',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Mail\\MailMessage',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Mail\\MailMessage';
     }
 
     /**
@@ -218,10 +177,7 @@ class Typo3Classes
      */
     public static function getHtmlParserClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_parsehtml',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Html\\HtmlParser',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Html\\HtmlParser';
     }
 
     /**
@@ -231,10 +187,7 @@ class Typo3Classes
      */
     public static function getGeneralUtilityClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_div',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Utility\\GeneralUtility',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Utility\\GeneralUtility';
     }
 
     /**
@@ -242,10 +195,7 @@ class Typo3Classes
      */
     public static function getTypoScriptParserClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_TSparser',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\TypoScript\\Parser\\TypoScriptParser',
-        ]);
+        return 'TYPO3\\CMS\\Core\\TypoScript\\Parser\\TypoScriptParser';
     }
 
     /**
@@ -253,10 +203,7 @@ class Typo3Classes
      */
     public static function getDocumentTemplateClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'template',
-            self::HIGHER6 => 'TYPO3\\CMS\\Backend\\Template\\DocumentTemplate',
-        ]);
+        return 'TYPO3\\CMS\\Backend\\Template\\DocumentTemplate';
     }
 
     /**
@@ -264,10 +211,7 @@ class Typo3Classes
      */
     public static function getTemplateServiceClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_TStemplate',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\TypoScript\\TemplateService',
-        ]);
+        return 'TYPO3\\CMS\\Core\\TypoScript\\TemplateService';
     }
 
     /**
@@ -275,10 +219,7 @@ class Typo3Classes
      */
     public static function getHttpUtilityClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_utility_Http',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Utility\\HttpUtility',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Utility\\HttpUtility';
     }
 
     /**
@@ -286,10 +227,7 @@ class Typo3Classes
      */
     public static function getMediumDocumentTemplateClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'mediumDoc',
-            self::HIGHER6 => 'TYPO3\\CMS\\Backend\\Template\\DocumentTemplate',
-        ]);
+        return 'TYPO3\\CMS\\Backend\\Template\\DocumentTemplate';
     }
 
     /**
@@ -297,10 +235,7 @@ class Typo3Classes
      */
     public static function getLocalizationParserClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_l10n_parser_Llxml',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Localization\\Parser\\LocallangXmlParser',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Localization\\Parser\\LocallangXmlParser';
     }
 
     /**
@@ -308,10 +243,7 @@ class Typo3Classes
      */
     public static function getAbstractUserAuthenticationClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_userAuth',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Authentication\\AbstractUserAuthentication',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Authentication\\AbstractUserAuthentication';
     }
 
     /**
@@ -319,10 +251,7 @@ class Typo3Classes
      */
     public static function getAbstractRteClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_rteapi',
-            self::HIGHER6 => 'TYPO3\\CMS\\Backend\\Rte\\AbstractRte',
-        ]);
+        return 'TYPO3\\CMS\\Backend\\Rte\\AbstractRte';
     }
 
     /**
@@ -330,10 +259,7 @@ class Typo3Classes
      */
     public static function getSqlParserClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_sqlparser',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Database\\SqlParser',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Database\\SqlParser';
     }
 
     /**
@@ -341,10 +267,7 @@ class Typo3Classes
      */
     public static function getFrontendBackendUserAuthenticationClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_tsfeBeUserAuth',
-            self::HIGHER6 => 'TYPO3\\CMS\\Backend\\FrontendBackendUserAuthentication',
-        ]);
+        return 'TYPO3\\CMS\\Backend\\FrontendBackendUserAuthentication';
     }
 
     /**
@@ -352,10 +275,7 @@ class Typo3Classes
      */
     public static function getBackendUserAuthenticationClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 't3lib_beUserAuth',
-            self::HIGHER6 => 'TYPO3\\CMS\\Core\\Authentication\\BackendUserAuthentication',
-        ]);
+        return 'TYPO3\\CMS\\Core\\Authentication\\BackendUserAuthentication';
     }
 
     /**
@@ -363,10 +283,7 @@ class Typo3Classes
      */
     public static function getEidUtilityClass()
     {
-        return self::getClassByCurrentTypo3Version([
-            self::LOWER6 => 'tslib_eidtools',
-            self::HIGHER6 => 'TYPO3\\CMS\\Frontend\\Utility\\EidUtility',
-        ]);
+        return 'TYPO3\\CMS\\Frontend\\Utility\\EidUtility';
     }
 
     /**

--- a/mod/class.tx_rnbase_mod_BaseModule.php
+++ b/mod/class.tx_rnbase_mod_BaseModule.php
@@ -362,7 +362,7 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
      */
     public function useModuleTemplate()
     {
-        return tx_rnbase_util_TYPO3::isTYPO76OrHigher();
+        return true;
     }
 
     /**

--- a/tests/Classes/Utility/TcaToolTest.php
+++ b/tests/Classes/Utility/TcaToolTest.php
@@ -65,11 +65,8 @@ class Tx_Rnbase_Utility_TcaToolTest extends tx_rnbase_tests_BaseTestCase
         if (tx_rnbase_util_TYPO3::isTYPO87OrHigher()) {
             $expectedLinkWizard['link']['icon'] = 'actions-add';
             $expectedLinkWizard['link']['module']['name'] = 'wizard_link';
-        } elseif (tx_rnbase_util_TYPO3::isTYPO76OrHigher()) {
-            $expectedLinkWizard['link']['icon'] = 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif';
-            $expectedLinkWizard['link']['module']['name'] = 'wizard_element_browser';
         } else {
-            $expectedLinkWizard['link']['icon'] = 'EXT:t3skin/icons/gfx/link_popup.gif';
+            $expectedLinkWizard['link']['icon'] = 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif';
             $expectedLinkWizard['link']['module']['name'] = 'wizard_element_browser';
         }
         self::assertEquals(ksort($expectedLinkWizard), ksort($linkWizard), 'link wizard nicht korrekt');
@@ -147,7 +144,7 @@ class Tx_Rnbase_Utility_TcaToolTest extends tx_rnbase_tests_BaseTestCase
                 'actions-wizard-link',
                 $wizards['link']['icon']
             );
-        } elseif (tx_rnbase_util_TYPO3::isTYPO76OrHigher()) {
+        } else {
             self::assertEquals(
                 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_add.gif',
                 $wizards['add']['icon']
@@ -166,27 +163,6 @@ class Tx_Rnbase_Utility_TcaToolTest extends tx_rnbase_tests_BaseTestCase
             );
             self::assertEquals(
                 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif',
-                $wizards['link']['icon']
-            );
-        } else {
-            self::assertEquals(
-                'EXT:t3skin/icons/gfx/add.gif',
-                $wizards['add']['icon']
-            );
-            self::assertEquals(
-                'EXT:t3skin/icons/gfx/edit2.gif',
-                $wizards['edit']['icon']
-            );
-            self::assertEquals(
-                'EXT:t3skin/icons/gfx/list.gif',
-                $wizards['list']['icon']
-            );
-            self::assertEquals(
-                'EXT:t3skin/icons/gfx/wizard_rte.gif',
-                $wizards['RTE']['icon']
-            );
-            self::assertEquals(
-                'EXT:t3skin/icons/gfx/link_popup.gif',
                 $wizards['link']['icon']
             );
         }

--- a/tests/class.tx_rnbase_tests_BaseTestCase.php
+++ b/tests/class.tx_rnbase_tests_BaseTestCase.php
@@ -603,13 +603,11 @@ abstract class tx_rnbase_tests_BaseTestCase extends \PHPUnit\Framework\TestCase
 
     protected function resetIndependentEnvironmentCache()
     {
-        if (tx_rnbase_util_TYPO3::isTYPO76OrHigher()) {
-            $property = new ReflectionProperty(
-                tx_rnbase_util_Typo3Classes::getGeneralUtilityClass(),
-                'indpEnvCache'
-            );
-            $property->setAccessible(true);
-            $property->setValue(null, []);
-        }
+        $property = new ReflectionProperty(
+            tx_rnbase_util_Typo3Classes::getGeneralUtilityClass(),
+            'indpEnvCache'
+        );
+        $property->setAccessible(true);
+        $property->setValue(null, []);
     }
 }

--- a/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
+++ b/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
@@ -283,11 +283,7 @@ class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertContains('&amp;sortField=uid&amp;sortRev=desc">Header Uid', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 1. teil');
 
         //der korrekte pfeil?
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $this->assertContains('icon-actions-move-down', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        } else {
-            $this->assertContains('gfx/reddown.gif', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        }
+        $this->assertContains('icon-actions-move-down', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
         $this->assertEquals('Header Col1', $aRet[0][0][1], 'Die zweite Zelle des Headers ist falsch.');
         //erste Zeile
         $this->assertEquals(2, count($aRet[0][1]), 'Das Array der ersten Zeile hat die falsche Anzahl an Elementen.');
@@ -333,11 +329,7 @@ class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertEquals(2, count($aRet[0][0]), 'Das Array des Headers hat die falsche Anzahl an Elementen.');
         $this->assertContains('&amp;sortField=uid&amp;sortRev=asc">Header Uid', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 1. teil');
         //der korrekte pfeil?
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $this->assertContains('icon-actions-move-up', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        } else {
-            $this->assertContains('gfx/redup.gif', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        }
+        $this->assertContains('icon-actions-move-up', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
         $this->assertEquals('Header Col1', $aRet[0][0][1], 'Die zweite Zelle des Headers ist falsch.');
         //erste Zeile
         $this->assertEquals(2, count($aRet[0][1]), 'Das Array der ersten Zeile hat die falsche Anzahl an Elementen.');
@@ -386,11 +378,7 @@ class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
         $this->assertEquals(2, count($aRet[0][0]), 'Das Array des Headers hat die falsche Anzahl an Elementen.');
         $this->assertContains('&amp;additionalParam=test&amp;sortField=uid&amp;sortRev=asc">Header Uid', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 1. teil');
         //der korrekte pfeil?
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $this->assertContains('icon-actions-move-up', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        } else {
-            $this->assertContains('gfx/redup.gif', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
-        }
+        $this->assertContains('icon-actions-move-up', $aRet[0][0][0], 'Die erste Zelle des Headers ist falsch. 2. teil');
         $this->assertEquals('Header Col1', $aRet[0][0][1], 'Die zweite Zelle des Headers ist falsch.');
         //erste Zeile
         $this->assertEquals(2, count($aRet[0][1]), 'Das Array der ersten Zeile hat die falsche Anzahl an Elementen.');

--- a/util/class.tx_rnbase_util_Lang.php
+++ b/util/class.tx_rnbase_util_Lang.php
@@ -74,24 +74,18 @@ class tx_rnbase_util_Lang
         $errorMode = 0,
         $isLocalizationOverride = false
     ) {
-        if (tx_rnbase_util_TYPO3::isTYPO74OrHigher()) {
-            /** @var $languageFactory \TYPO3\CMS\Core\Localization\LocalizationFactory */
-            $languageFactory = tx_rnbase::makeInstance(
-                'TYPO3\\CMS\\Core\\Localization\\LocalizationFactory'
-            );
+        /** @var $languageFactory \TYPO3\CMS\Core\Localization\LocalizationFactory */
+        $languageFactory = tx_rnbase::makeInstance(
+            'TYPO3\\CMS\\Core\\Localization\\LocalizationFactory'
+        );
 
-            return $languageFactory->getParsedData(
-                $fileReference,
-                $languageKey,
-                $charset,
-                $errorMode,
-                $isLocalizationOverride
-            );
-        }
-
-        $utility = tx_rnbase_util_Typo3Classes::getGeneralUtilityClass();
-
-        return $utility::readLLfile($fileReference, $languageKey, $charset);
+        return $languageFactory->getParsedData(
+            $fileReference,
+            $languageKey,
+            $charset,
+            $errorMode,
+            $isLocalizationOverride
+        );
     }
 
     /**

--- a/util/class.tx_rnbase_util_Templates.php
+++ b/util/class.tx_rnbase_util_Templates.php
@@ -472,16 +472,10 @@ class tx_rnbase_util_Templates
      */
     public static function substituteSubpart($content, $marker, $subpartContent, $recursive = 1)
     {
-        if (tx_rnbase_util_TYPO3::isTYPO70OrHigher()) {
-            $parser = tx_rnbase::makeInstance(
-                'TYPO3\\CMS\\Core\\Service\\MarkerBasedTemplateService'
-            );
+        $parser = tx_rnbase::makeInstance(
+            'TYPO3\\CMS\\Core\\Service\\MarkerBasedTemplateService'
+        );
 
-            return $parser->substituteSubpart($content, $marker, $subpartContent, $recursive);
-        } else {
-            $parser = tx_rnbase_util_Typo3Classes::getHtmlParserClass();
-
-            return $parser::substituteSubpart($content, $marker, $subpartContent, $recursive);
-        }
+        return $parser->substituteSubpart($content, $marker, $subpartContent, $recursive);
     }
 }


### PR DESCRIPTION
As we require TYPO3 >= 7.6, there is no need to keep code that is
specific to older TYPO3 versions.