### PR TITLE
Fix ordering for implode parameters

### DIFF
--- a/Classes/ExtBaseFluid/ViewHelper/PageBrowserViewHelper.php
+++ b/Classes/ExtBaseFluid/ViewHelper/PageBrowserViewHelper.php
@@ -125,7 +125,7 @@ class PageBrowserViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTa
             $maxPages,
             $totalPages
         );
-        $result = implode($pageBrowserHtmlParts, $implode ? $implode : ' ');
+        $result = implode($implode ? $implode : ' ', $pageBrowserHtmlParts);
 
         $this->templateVariableContainer->remove('count');
         $this->templateVariableContainer->remove('totalPages');


### PR DESCRIPTION
Passing the separator after the array (i.e. using the legacy signature) has been deprecated.
https://www.php.net/manual/de/function.implode.php