### PR TITLE
[BUGFIX] Pin the php-cs-fixer version

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -14,5 +14,5 @@ jobs:
               uses: shivammathur/setup-php@master
               with:
                   php-version: 7.3
-            - run: composer require friendsofphp/php-cs-fixer
+            - run: composer install --no-progress
             - run: .Build/bin/php-cs-fixer fix --diff --dry-run

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "nimut/testing-framework": "^1.1 || ^2.0 || ^4.0 || ^5.0",
         "mikey179/vfsstream": "^1.4 || ^1.6",
         "phpunit/phpunit": "^4.7|| ^7.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "3.0.0"
     },
     "suggest": {
         "ext-mcrypt": "*",


### PR DESCRIPTION
Newer versions have a bug that complaing about perfectly well-formatted
code and insert bogus `|` characters in funny places.

Also fix the CI step for installing the fixer.