### PR TITLE
[CLEANUP] Drop `type="text/javascript"` from some `script` tags

### DIFF
--- a/Classes/Backend/Template/ModuleTemplate.php
+++ b/Classes/Backend/Template/ModuleTemplate.php
@@ -176,7 +176,7 @@ class Tx_Rnbase_Backend_Template_ModuleTemplate
 //            $doc->getPageRenderer()->loadJquery();
         // JavaScript
         $doc->JScode .= '
-            <script language="javascript" type="text/javascript">
+            <script>
                 script_ended = 0;
                 function jumpToUrl(URL)	{
                     document.location = URL;
@@ -186,7 +186,7 @@ class Tx_Rnbase_Backend_Template_ModuleTemplate
 
         // TODO: Die Zeile könnte problematisch sein...
         $doc->postCode = '
-            <script language="javascript" type="text/javascript">
+            <script>
                 script_ended = 1;
                 if (top.fsMod) top.fsMod.recentIds["web"] = '.$this->options['pid'].';</script>';
     }

--- a/Classes/Backend/Template/Override/DocumentTemplate.php
+++ b/Classes/Backend/Template/Override/DocumentTemplate.php
@@ -382,7 +382,7 @@ function jumpToUrl(URL) {
             if (TAB === $string[0]) {
                 $string = TAB.ltrim($string, TAB);
             }
-            $string = $cr.'<script type="text/javascript">
+            $string = $cr.'<script>
 /*<![CDATA[*/
 '.$string.'
 /*]]>*/

--- a/mod/class.tx_rnbase_mod_BaseModule.php
+++ b/mod/class.tx_rnbase_mod_BaseModule.php
@@ -510,7 +510,7 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
         $doc->loadJavascriptLib('contrib/prototype/prototype.js');
         // JavaScript
         $doc->JScode .= '
-            <script language="javascript" type="text/javascript">
+            <script>
                 script_ended = 0;
                 function jumpToUrl(URL)	{
                     document.location = URL;
@@ -520,7 +520,7 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
 
         // TODO: Die Zeile könnte problematisch sein...
         $doc->postCode = '
-            <script language="javascript" type="text/javascript">
+            <script>
                 script_ended = 1;
                 if (top.fsMod) top.fsMod.recentIds["web"] = '.$this->id.';</script>';
     }


### PR DESCRIPTION
This is not needed anymore with modern HTML versions.