### PR TITLE
[TASK] Drop the Travis CI badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@ rn_base
 [![rn_base](ext_icon.gif)](https://github.com/digedag/rn_base)
 [![Latest Stable Version](https://img.shields.io/packagist/v/digedag/rn-base.svg?maxAge=3600&style=flat-square)](https://packagist.org/packages/digedag/rn-base)
 [![Total Downloads](https://img.shields.io/packagist/dt/digedag/rn-base.svg?maxAge=3600&style=flat-square)](https://packagist.org/packages/digedag/rn-base)
-[![Build Status](https://api.travis-ci.org/digedag/rn_base.png)](https://travis-ci.org/digedag/rn_base)
 [![Code Style](https://github.com/digedag/rn_base/actions/workflows/php.yaml/badge.svg)](https://github.com/digedag/rn_base/actions/workflows/php.yaml)
 [![License](https://img.shields.io/packagist/l/digedag/rn-base.svg?maxAge=3600&style=flat-square)](https://packagist.org/packages/digedag/rn-base)
 
 What is this extension for?
 ---------------------------
 
-This is a base library to develop extensions for Content Management System TYPO3. It is based and 
-includes many code of extension "lib". I wrote this extension because I don't like the code design 
-of "lib". For my taste there is too much inheritance, too much dependency and unclear responsibilities 
+This is a base library to develop extensions for Content Management System TYPO3. It is based and
+includes many code of extension "lib". I wrote this extension because I don't like the code design
+of "lib". For my taste there is too much inheritance, too much dependency and unclear responsibilities
 between the used classes.
 
 


### PR DESCRIPTION
Travis CI does not support open source projects for free anymore,
and there have been no new builds for quite some time.