### PR TITLE
[TASK] Update the development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
         "ext-zip": "*"
     },
     "require-dev": {
-        "namelesscoder/typo3-repository-client": "^1.2",
-        "nimut/testing-framework": "^1.1 || ^2.0 || ^4.0 || ^5.0",
-        "mikey179/vfsstream": "^1.4 || ^1.6",
-        "phpunit/phpunit": "^4.7|| ^7.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "namelesscoder/typo3-repository-client": "^1.3.1",
+        "nimut/testing-framework": "^5.2.1",
+        "mikey179/vfsstream": "^1.6.10",
+        "phpunit/phpunit": "^7.5.20",
+        "friendsofphp/php-cs-fixer": "^3.1.0"
     },
     "suggest": {
         "ext-mcrypt": "*",


### PR DESCRIPTION
With the current PHP and TYPO3 version constraints, there is no need
to support older versions of the development dependencies anymore.