### PR TITLE
[BUGFIX] Remove manual autoloading of autoloadable classes

### DIFF
--- a/Classes/Backend/Decorator/BaseDecorator.php
+++ b/Classes/Backend/Decorator/BaseDecorator.php
@@ -22,9 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Backend_Decorator_InterfaceDecorator');
-tx_rnbase::load('tx_rnbase_util_TCA');
-
 /**
  * Base Decorator.
  *
@@ -58,7 +55,6 @@ class Tx_Rnbase_Backend_Decorator_BaseDecorator implements Tx_Rnbase_Backend_Dec
     ) {
         $this->mod = $mod;
 
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $this->options = Tx_Rnbase_Domain_Model_Data::getInstance($options);
     }
 
@@ -110,7 +106,6 @@ class Tx_Rnbase_Backend_Decorator_BaseDecorator implements Tx_Rnbase_Backend_Dec
     ) {
         $return = $columnValue;
 
-        tx_rnbase::load('tx_rnbase_util_Strings');
         $method = tx_rnbase_util_Strings::underscoredToLowerCamelCase($columnName);
         $method = 'format'.ucfirst($method).'Column';
 
@@ -376,7 +371,6 @@ class Tx_Rnbase_Backend_Decorator_BaseDecorator implements Tx_Rnbase_Backend_Dec
                 ]
             );
         } else {
-            tx_rnbase::load('tx_rnbase_mod_Util');
             $action = tx_rnbase_mod_Util::getSpriteIcon('empty-icon');
         }
 
@@ -411,7 +405,6 @@ class Tx_Rnbase_Backend_Decorator_BaseDecorator implements Tx_Rnbase_Backend_Dec
                 ]
             );
         } else {
-            tx_rnbase::load('tx_rnbase_mod_Util');
             $action = tx_rnbase_mod_Util::getSpriteIcon('empty-icon');
         }
 

--- a/Classes/Backend/Form/ToolBox.php
+++ b/Classes/Backend/Form/ToolBox.php
@@ -217,7 +217,6 @@ class Tx_Rnbase_Backend_Form_ToolBox
                 ' title="'.$label.'\" alt="" >';
         }
         if ($options['sprite']) {
-            tx_rnbase::load('tx_rnbase_mod_Util');
             $label = tx_rnbase_mod_Util::getSpriteIcon($options['sprite']);
         }
         $jsCode = Tx_Rnbase_Backend_Utility::viewOnClick($pid, '', '', '', '', $urlParams);

--- a/Classes/Backend/Handler/DetailHandler.php
+++ b/Classes/Backend/Handler/DetailHandler.php
@@ -22,8 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Backend_Handler_SearchHandler');
-
 /**
  * Abstract detail handler.
  *

--- a/Classes/Backend/Handler/SearchHandler.php
+++ b/Classes/Backend/Handler/SearchHandler.php
@@ -22,8 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_mod_IModHandler');
-
 /**
  * Abstract search handler.
  *

--- a/Classes/Backend/Lister/AbstractLister.php
+++ b/Classes/Backend/Lister/AbstractLister.php
@@ -22,8 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Backend_Decorator_InterfaceDecorator');
-
 /**
  * Abstract Lister.
  *
@@ -59,7 +57,6 @@ abstract class Tx_Rnbase_Backend_Lister_AbstractLister
      */
     protected function getListerId()
     {
-        tx_rnbase::load('Tx_Rnbase_Utility_Strings');
         $confId = str_replace('\\', '_', get_class($this));
         $confId = Tx_Rnbase_Utility_Strings::underscoredToLowerCamelCase($confId);
 
@@ -76,7 +73,6 @@ abstract class Tx_Rnbase_Backend_Lister_AbstractLister
         tx_rnbase_mod_BaseModule $module,
         $options = []
     ) {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $this->storage = Tx_Rnbase_Domain_Model_Data::getInstance(
             [
                 'module' => $module,
@@ -271,7 +267,6 @@ abstract class Tx_Rnbase_Backend_Lister_AbstractLister
     protected function getDecoratorUtility()
     {
         if (!$this->getStorage()->hasDecoratorUtility()) {
-            tx_rnbase::load('Tx_Rnbase_Backend_Utility_DecoratorUtility');
             $this->getStorage()->setDecoratorUtility(
                 Tx_Rnbase_Backend_Utility_DecoratorUtility::getInstance(
                     $this->getDecorator(),
@@ -295,8 +290,6 @@ abstract class Tx_Rnbase_Backend_Lister_AbstractLister
     public function renderTemplate(
         $template
     ) {
-        tx_rnbase::load('tx_rnbase_util_Templates');
-
         return tx_rnbase_util_Templates::substituteMarkerArrayCached(
             $template,
             $this->renderListMarkers()
@@ -444,8 +437,6 @@ abstract class Tx_Rnbase_Backend_Lister_AbstractLister
      */
     protected function getSearcherUtility()
     {
-        tx_rnbase::load('Tx_Rnbase_Backend_Utility_SearcherUtility');
-
         return Tx_Rnbase_Backend_Utility_SearcherUtility::getInstance(
             $this->getOptions()
         );

--- a/Classes/Backend/Utility/DecoratorUtility.php
+++ b/Classes/Backend/Utility/DecoratorUtility.php
@@ -73,7 +73,6 @@ class Tx_Rnbase_Backend_Utility_DecoratorUtility
         $options = []
     ) {
         $this->decorator = $decorator;
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $this->options = Tx_Rnbase_Domain_Model_Data::getInstance($options);
     }
 
@@ -130,7 +129,6 @@ class Tx_Rnbase_Backend_Utility_DecoratorUtility
         array &$columns
     ) {
         if ($this->getOptions()->hasBaseTableName()) {
-            tx_rnbase::load('tx_rnbase_util_TCA');
             $labelField = tx_rnbase_util_TCA::getLabelFieldForTable(
                 $this->getOptions()->getBaseTableName()
             );
@@ -161,7 +159,6 @@ class Tx_Rnbase_Backend_Utility_DecoratorUtility
         array &$columns
     ) {
         if ($this->getOptions()->hasBaseTableName()) {
-            tx_rnbase::load('tx_rnbase_util_TCA');
             $sysLanguageUidField = tx_rnbase_util_TCA::getLanguageFieldForTable(
                 $this->getOptions()->getBaseTableName()
             );

--- a/Classes/Backend/Utility/SearcherUtility.php
+++ b/Classes/Backend/Utility/SearcherUtility.php
@@ -60,7 +60,6 @@ class Tx_Rnbase_Backend_Utility_SearcherUtility
     public function __construct(
         $options = []
     ) {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $this->options = Tx_Rnbase_Domain_Model_Data::getInstance($options);
     }
 
@@ -91,7 +90,6 @@ class Tx_Rnbase_Backend_Utility_SearcherUtility
         // we has to build a uid map for sortable tables!
         $firstPrev = $lastNext = false;
         $baseTableName = $this->getOptions()->getBaseTableName();
-        tx_rnbase::load('tx_rnbase_util_TCA');
         if ((
             $baseTableName
             && tx_rnbase_util_TCA::getSortbyFieldForTable($baseTableName)

--- a/Classes/Backend/Utility/Tables.php
+++ b/Classes/Backend/Utility/Tables.php
@@ -231,7 +231,6 @@ class Tx_Rnbase_Backend_Utility_Tables
     private function getLangOverlayEntries(
         Tx_Rnbase_Domain_Model_RecordInterface $entry
     ) {
-        tx_rnbase::load('tx_rnbase_util_TCA');
         $parentField = tx_rnbase_util_TCA::getTransOrigPointerFieldForTable($entry->getTableName());
         $overlays = tx_rnbase_util_DB::doSelect(
             '*',

--- a/Classes/Backend/Utility/TcaTool.php
+++ b/Classes/Backend/Utility/TcaTool.php
@@ -103,7 +103,6 @@ class TcaTool
      * Add a wizard to column.
      * Usage:.
      *
-     * tx_rnbase::load('Tx_Rnbase_Util_TCA');
      * $tca = new Tx_Rnbase_Util_TCA();
      * $tca->addWizard($tcaTableArray, 'teams', 'add', 'wizard_add', array());
      *

--- a/Classes/Configuration/Processor.php
+++ b/Classes/Configuration/Processor.php
@@ -548,8 +548,6 @@ class Processor implements \Tx_Rnbase_Configuration_ProcessorInterface
     {
         static $flex;
         if (!is_array($flex)) {
-            \tx_rnbase::load('tx_rnbase_util_Network');
-            \tx_rnbase::load('tx_rnbase_util_Arrays');
             $flex = \tx_rnbase_util_Network::getUrl(\tx_rnbase_util_Extensions::extPath($this->getExtensionKey()).$this->get('flexform'));
             $flex = \tx_rnbase_util_Arrays::xml2array($flex);
         }
@@ -992,7 +990,6 @@ class Processor implements \Tx_Rnbase_Configuration_ProcessorInterface
         if (is_array($xmlOrArray)) {
             $array = $xmlOrArray;
         } else {
-            \tx_rnbase::load('tx_rnbase_util_Arrays');
             $array = \tx_rnbase_util_Arrays::xml2array($xmlOrArray);
         }
         $data = $array['data'];

--- a/Classes/Database/Connection.php
+++ b/Classes/Database/Connection.php
@@ -468,7 +468,6 @@ class Connection implements SingletonInterface
         // the connection has to be reconected after cache load,
         // so only the credentials are stored in cache, but this is critical,
         // so the cache was removed for the moment!
-//        tx_rnbase::load('tx_rnbase_cache_Manager');
 //        $cache = tx_rnbase_cache_Manager::getCache('rnbase_databases');
 //        $db = $cache->get('db_' . $key);
 //        if (!$db) {

--- a/Classes/Domain/Collection/Base.php
+++ b/Classes/Domain/Collection/Base.php
@@ -22,7 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Utility_Composer');
 Tx_Rnbase_Utility_Composer::autoload();
 
 /**

--- a/Classes/Domain/Model/Base.php
+++ b/Classes/Domain/Model/Base.php
@@ -22,11 +22,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
 tx_rnbase::load('Tx_Rnbase_Domain_Model_DomainInterface');
 tx_rnbase::load('Tx_Rnbase_Domain_Model_DynamicTableInterface');
 tx_rnbase::load('Tx_Rnbase_Domain_Model_RecordInterface');
-tx_rnbase::load('tx_rnbase_util_TCA');
 
 /**
  * Basisklasse für die meisten Model-Klassen.
@@ -92,7 +90,6 @@ class Tx_Rnbase_Domain_Model_Base extends Tx_Rnbase_Domain_Model_Data implements
             return;
         }
 
-        tx_rnbase::load('Tx_Rnbase_Database_Connection');
         $db = Tx_Rnbase_Database_Connection::getInstance();
         $record = $db->getRecord(
             $this->getTableName(),
@@ -206,7 +203,6 @@ class Tx_Rnbase_Domain_Model_Base extends Tx_Rnbase_Domain_Model_Data implements
             $field = tx_rnbase_util_TCA::getCrdateFieldForTable($tableName);
             if (!$this->isPropertyEmpty($field)) {
                 $tstamp = (int) $this->getProperty($field);
-                tx_rnbase::load('tx_rnbase_util_Dates');
                 $datetime = tx_rnbase_util_Dates::getDateTime(
                     '@'.$tstamp,
                     $timezone
@@ -233,7 +229,6 @@ class Tx_Rnbase_Domain_Model_Base extends Tx_Rnbase_Domain_Model_Data implements
             $field = tx_rnbase_util_TCA::getTstampFieldForTable($tableName);
             if (!$this->isPropertyEmpty($field)) {
                 $tstamp = (int) $this->getProperty($field);
-                tx_rnbase::load('tx_rnbase_util_Dates');
                 $datetime = tx_rnbase_util_Dates::getDateTime(
                     '@'.$tstamp,
                     $timezone

--- a/Classes/Domain/Model/Data.php
+++ b/Classes/Domain/Model/Data.php
@@ -237,8 +237,6 @@ class Tx_Rnbase_Domain_Model_Data implements Tx_Rnbase_Domain_Model_DataInterfac
      */
     protected function underscore($string)
     {
-        tx_rnbase::load('Tx_Rnbase_Utility_Strings');
-
         return Tx_Rnbase_Utility_Strings::camelCaseToLowerCaseUnderscored($string);
     }
 

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -48,7 +48,6 @@ abstract class Tx_Rnbase_Domain_Repository_AbstractRepository implements Tx_Rnba
      */
     protected function getSearcher()
     {
-        tx_rnbase::load('tx_rnbase_util_SearchBase');
         $searcher = tx_rnbase_util_SearchBase::getInstance($this->getSearchClass());
         if (!$searcher instanceof tx_rnbase_util_SearchBase) {
             throw new Exception(get_class($this).'->getSearchClass() has to return a classname'.' of class which extends tx_rnbase_util_SearchBase!');

--- a/Classes/Domain/Repository/PersistenceRepository.php
+++ b/Classes/Domain/Repository/PersistenceRepository.php
@@ -22,7 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Domain_Repository_AbstractRepository');
 tx_rnbase::load('Tx_Rnbase_Domain_Repository_InterfacePersistence');
 
 /**
@@ -71,7 +70,6 @@ abstract class Tx_Rnbase_Domain_Repository_PersistenceRepository extends Tx_Rnba
         Tx_Rnbase_Domain_Model_DomainInterface $model,
         $options = null
     ) {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $options = Tx_Rnbase_Domain_Model_Data::getInstance($options);
 
         // check for right instance
@@ -88,7 +86,6 @@ abstract class Tx_Rnbase_Domain_Repository_PersistenceRepository extends Tx_Rnba
             return;
         }
 
-        tx_rnbase::load('tx_rnbase_util_TCA');
         $tableName = $this->getEmptyModel()->getTableName();
 
         // the data to write
@@ -234,7 +231,6 @@ abstract class Tx_Rnbase_Domain_Repository_PersistenceRepository extends Tx_Rnba
             return [];
         }
 
-        tx_rnbase::load('tx_rnbase_util_Arrays');
         $data = tx_rnbase_util_Arrays::removeNotIn(
             $model->getProperty(),
             array_merge(

--- a/Classes/Exception/PageNotFound404.php
+++ b/Classes/Exception/PageNotFound404.php
@@ -21,7 +21,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
-tx_rnbase::load('Tx_Rnbase_Exception_Base');
 
 /**
  * Wird diese Exception innerhalb einer Action geworfen,

--- a/Classes/Frontend/Controller/AbstractAction.php
+++ b/Classes/Frontend/Controller/AbstractAction.php
@@ -119,7 +119,6 @@ abstract class AbstractAction
      */
     protected function addResources(ConfigurationInterface $configurations, $confId)
     {
-        \tx_rnbase::load('tx_rnbase_util_Files');
         $pageRenderer = \tx_rnbase_util_TYPO3::getPageRenderer();
 
         foreach ($this->getJavaScriptFilesByIncludePartConfId($configurations, 'includeJSFooter') as $file) {

--- a/Classes/Frontend/Marker/Utility.php
+++ b/Classes/Frontend/Marker/Utility.php
@@ -53,7 +53,6 @@ class Tx_Rnbase_Frontend_Marker_Utility
             }
         }
         if ($minfo) {
-            tx_rnbase::load('tx_rnbase_util_Debug');
             $item->setProperty('__MINFO', tx_rnbase_util_Debug::viewArray($minfoArr));
         }
 

--- a/Classes/Frontend/View/Marker/BaseView.php
+++ b/Classes/Frontend/View/Marker/BaseView.php
@@ -46,7 +46,6 @@ class BaseView extends AbstractView implements ViewInterface
         $this->_init($configurations);
         $templateCode = \tx_rnbase_util_Files::getFileResource($this->getTemplate($view, '.html'));
         if (!strlen($templateCode)) {
-            \tx_rnbase::load('tx_rnbase_util_Misc');
             \tx_rnbase_util_Misc::mayday('TEMPLATE NOT FOUND: '.$this->getTemplate($view, '.html'));
         }
 
@@ -59,7 +58,6 @@ class BaseView extends AbstractView implements ViewInterface
         if (!empty($subpart)) {
             $templateCode = \tx_rnbase_util_Templates::getSubpart($templateCode, $subpart);
             if (!strlen($templateCode)) {
-                \tx_rnbase::load('tx_rnbase_util_Misc');
                 \tx_rnbase_util_Misc::mayday('SUBPART NOT FOUND: '.$subpart);
             }
         }

--- a/Classes/Search/SearchBase.php
+++ b/Classes/Search/SearchBase.php
@@ -764,7 +764,6 @@ abstract class SearchBase
                      */
                     if (isset($options[$optionName]) && !is_array($options[$optionName])) {
                         if (!in_array($optionName, ['override', 'force'])) {
-                            tx_rnbase::load('tx_rnbase_util_Logger');
                             tx_rnbase_util_Logger::warn(
                                 'Invalid configuration for config option "'.$optionName.'".',
                                 'rn_base',

--- a/Classes/Utility/Crypt.php
+++ b/Classes/Utility/Crypt.php
@@ -64,7 +64,6 @@ class Tx_Rnbase_Utility_Crypt
      */
     public function __construct($config = null)
     {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
         $this->config = Tx_Rnbase_Domain_Model_Data::getInstance($config);
         $this->init();
     }

--- a/Classes/Utility/Misc.php
+++ b/Classes/Utility/Misc.php
@@ -681,7 +681,6 @@ MAYDAYPAGE;
         $ignoreMailLock = (array_key_exists('ignoremaillock', $options) && $options['ignoremaillock']);
 
         if (!$ignoreMailLock) {
-            tx_rnbase::load('tx_rnbase_util_Lock');
             // Only one mail within one minute!
             $lock = tx_rnbase_util_Lock::getInstance('errormail', 60);
             if ($lock->isLocked()) {
@@ -722,7 +721,6 @@ MAYDAYPAGE;
         $textPart .= "Stacktrace:\n".$e->__toString()."\n";
         $textPart .= 'SITE_URL: '.self::getIndpEnv('TYPO3_SITE_URL')."\n";
 
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         $textPart .= 'BE_USER: '.TYPO3::getBEUserUID()."\n";
         $textPart .= 'FE_USER: '.TYPO3::getFEUserUID()."\n";
 
@@ -760,7 +758,6 @@ MAYDAYPAGE;
             }
         }
 
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         $htmlPart .= '<p><strong>BE_USER:</strong> '.TYPO3::getBEUserUID().'</p>';
         $htmlPart .= '<p><strong>FE_USER:</strong> '.TYPO3::getFEUserUID().'</p>';
 

--- a/Classes/Utility/WizIcon.php
+++ b/Classes/Utility/WizIcon.php
@@ -37,7 +37,6 @@ abstract class Tx_Rnbase_Utility_WizIcon
      */
     public static function addWizicon($clazz, $clazzFile)
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         if (!tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
             $GLOBALS['TBE_MODULES_EXT']['xMOD_db_new_content_el']['addElClasses'][$id] = $clazz;
         } else {

--- a/Documentation/cache_api.md
+++ b/Documentation/cache_api.md
@@ -6,7 +6,6 @@ TYPO3 hat mit der Version 4.3 eine eigene Cache-API eingeführt. Der Umgang dami
 rn_base schafft hier Abhilfe und bietet seit der Version 0.6.4 einen passenden Wrapper. Die Anwendung ist zunächst ganz einfach:
 
 ```php
-tx_rnbase::load('tx_rnbase_cache_Manager');
 $marker = tx_rnbase_cache_Manager::getCache('mycache')->get('tx_t3users_util_FEUserMarker');
 if(!$marker) {
   $marker = tx_rnbase::makeInstance('tx_t3users_util_FEUserMarker');
@@ -38,8 +37,7 @@ Weitere Infos gibt es im Web. Aber aufpassen, da sind einige Beispiele veraltet 
 Bei der Verwendung von rn_base kann man seinen Cache systemunabhängig registrieren. Die Cache-Manager-Klasse stellt dafür eine passende Methode bereit:
 
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
-    tx_rnbase_cache_Manager::registerCache('your_cache_name',
+            tx_rnbase_cache_Manager::registerCache('your_cache_name',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_MEMCACHED,
             array(
@@ -52,8 +50,7 @@ Konkretes Beispiel für DB-basierten Cache
 -----------------------------------------
 Für mkforms wird ein Cache verwendet, um Session-Daten zu persistieren. Der Cache hat die ID mkforms. Mit folgender Config in der Datei typo3conf/localconf.php wird der Cache auf Datenbank-Basis eingerichtet:
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
-    tx_rnbase_cache_Manager::registerCache('mkforms',
+            tx_rnbase_cache_Manager::registerCache('mkforms',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_T3DATABASE,
             array(
@@ -94,8 +91,7 @@ Konkretes Beispiel für MemCached
 So sollte es für memcached aussehen. Das ist aber noch ungetestet:
 
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
-    tx_rnbase_cache_Manager::registerCache('mkforms',
+            tx_rnbase_cache_Manager::registerCache('mkforms',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_MEMCACHED,
             array(
@@ -114,7 +110,7 @@ if (TYPO3_MODE == 'BE') {
         t3lib_cache::initializeCachingFramework();
         // State cache
         $GLOBALS['typo3CacheFactory']->create(
-                 'cf_mkmms', 
+                 'cf_mkmms',
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['frontend'],
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['backend'],
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['options']

--- a/Legacy/action/class.tx_rnbase_action_BaseIOC.php
+++ b/Legacy/action/class.tx_rnbase_action_BaseIOC.php
@@ -139,7 +139,6 @@ abstract class tx_rnbase_action_BaseIOC
      */
     protected function addResources($configurations, $confId)
     {
-        tx_rnbase::load('tx_rnbase_util_Files');
         $pageRenderer = tx_rnbase_util_TYPO3::getPageRenderer();
 
         foreach ($this->getJavaScriptFilesByIncludePartConfId('includeJSFooter') as $javaScriptConfId => $file) {

--- a/Legacy/action/class.tx_rnbase_action_CacheHandlerDefault.php
+++ b/Legacy/action/class.tx_rnbase_action_CacheHandlerDefault.php
@@ -22,7 +22,6 @@
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_action_ICacheHandler');
-tx_rnbase::load('tx_rnbase_cache_Manager');
 
 /**
  * A default CacheHandler.
@@ -188,7 +187,6 @@ class tx_rnbase_action_CacheHandlerDefault implements tx_rnbase_action_ICacheHan
     protected function getIcludeParams()
     {
         $params = $this->getConfigValue('include.params');
-        tx_rnbase::load('tx_rnbase_util_Strings');
 
         return tx_rnbase_util_Strings::trimExplode(',', $params, true);
     }
@@ -241,7 +239,6 @@ class tx_rnbase_action_CacheHandlerDefault implements tx_rnbase_action_ICacheHan
         $params = $this->getIcludeParams();
         if (!empty($params)) {
             // all get and post vars
-            tx_rnbase::load('tx_rnbase_util_Arrays');
             $gp = tx_rnbase_util_Arrays::mergeRecursiveWithOverrule(
                 Sys25\RnBase\Frontend\Request\Parameters::getGetParameters(),
                 Sys25\RnBase\Frontend\Request\Parameters::getPostParameters()

--- a/Legacy/action/class.tx_rnbase_action_CacheHandlerUser.php
+++ b/Legacy/action/class.tx_rnbase_action_CacheHandlerUser.php
@@ -21,10 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_action_CacheHandlerDefault');
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-tx_rnbase::load('tx_rnbase_cache_Manager');
-
 /**
  * Caching handler that saves data for feusers. For unregistered users the handler uses PHP-Session-ID
  * for identification.

--- a/Legacy/filter/class.tx_rnbase_filter_FilterItemMarker.php
+++ b/Legacy/filter/class.tx_rnbase_filter_FilterItemMarker.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-
 class tx_rnbase_filter_FilterItemMarker extends tx_rnbase_util_BaseMarker
 {
     public function parseTemplate($template, &$item, &$formatter, $confId, $marker = 'FILTERITEM')

--- a/Legacy/view/class.tx_rnbase_view_Base.php
+++ b/Legacy/view/class.tx_rnbase_view_Base.php
@@ -51,7 +51,6 @@ class tx_rnbase_view_Base
         $this->_init($configurations);
         $templateCode = tx_rnbase_util_Files::getFileResource($this->getTemplate($view, '.html'));
         if (!strlen($templateCode)) {
-            tx_rnbase::load('tx_rnbase_util_Misc');
             tx_rnbase_util_Misc::mayday('TEMPLATE NOT FOUND: '.$this->getTemplate($view, '.html'));
         }
 
@@ -62,7 +61,6 @@ class tx_rnbase_view_Base
         if (!empty($subpart)) {
             $templateCode = tx_rnbase_util_Templates::getSubpart($templateCode, $subpart);
             if (!strlen($templateCode)) {
-                tx_rnbase::load('tx_rnbase_util_Misc');
                 tx_rnbase_util_Misc::mayday('SUBPART NOT FOUND: '.$subpart);
             }
         }

--- a/Legacy/view/class.tx_rnbase_view_phpTemplateEngine.php
+++ b/Legacy/view/class.tx_rnbase_view_phpTemplateEngine.php
@@ -31,7 +31,6 @@
  *
  * @author René Nitzsche <rene@system25.de>
  */
-tx_rnbase::load('tx_rnbase_view_Base');
 
 /**
  * Base class for all views.

--- a/cache/class.tx_rnbase_cache_Manager.php
+++ b/cache/class.tx_rnbase_cache_Manager.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-
 /**
  * This class provides access to caches.
  */

--- a/cache/class.tx_rnbase_cache_TYPO3Cache62.php
+++ b/cache/class.tx_rnbase_cache_TYPO3Cache62.php
@@ -26,8 +26,6 @@ use TYPO3\CMS\Core\Cache\Frontend\NullFrontend;
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_cache_ICache');
-
 class tx_rnbase_cache_TYPO3Cache62 implements tx_rnbase_cache_ICache
 {
     private $cache; // The cache instance

--- a/class.tx_rnbase_controller.php
+++ b/class.tx_rnbase_controller.php
@@ -100,10 +100,6 @@ use Sys25\RnBase\Frontend\Request\Parameters;
  * @subpackage rn_base
  */
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-tx_rnbase::load('tx_rnbase_util_Arrays');
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 class tx_rnbase_controller
 {
     public $configurationsClassName = 'Tx_Rnbase_Configuration_Processor'; // You may overwrite this in your subclass with an own configurations class.
@@ -332,7 +328,6 @@ class tx_rnbase_controller
 
         if (!$exceptionHandler instanceof tx_rnbase_exception_IHandler) {
             $exceptionHandler = tx_rnbase::makeInstance($defaultExceptionHandlerClass);
-            tx_rnbase::load('tx_rnbase_util_Logger');
             tx_rnbase_util_Logger::fatal(
                 "the configured error handler ($exceptionHandlerClass) does not implement the tx_rnbase_exception_IHandler interface",
                 'rn_base'

--- a/exception/class.tx_rnbase_exception_Handler.php
+++ b/exception/class.tx_rnbase_exception_Handler.php
@@ -22,9 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-tx_rnbase::load('tx_rnbase_exception_IHandler');
-
 /**
  * @author Hannes Bochmann
  * @author Michael Wagner
@@ -53,7 +50,6 @@ class tx_rnbase_exception_Handler implements tx_rnbase_exception_IHandler
             header('HTTP/1.1 503 Service Unavailable');
         }
         // wir loggen nun den fehler
-        tx_rnbase::load('tx_rnbase_util_Logger');
         if (tx_rnbase_util_Logger::isFatalEnabled()) {
             $extKey = $configurations->getExtensionKey();
             $extKey = $extKey ? $extKey : 'rn_base';

--- a/exception/class.tx_rnbase_exception_ItemNotFound404.php
+++ b/exception/class.tx_rnbase_exception_ItemNotFound404.php
@@ -23,8 +23,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Exception_PageNotFound404');
-
 /**
  * Wird diese Exception innerhalb einer Action geworfen,
  * wird ein 404 Header gesetzt

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,8 +15,6 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations
 
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['rn_base']['loadHiddenObjects'] = (int) Tx_Rnbase_Configuration_Processor::getExtensionCfgValue('rn_base', 'loadHiddenObjects');
 
-//@TODO Warum funktioniert das Autolading hier nicht?
-tx_rnbase::load('Tx_Rnbase_Hook_DataHandler');
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['rn_base'] =
     'Tx_Rnbase_Hook_DataHandler->clearCacheForConfiguredTagsByTable';
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,7 +5,6 @@ defined('TYPO3_MODE') or exit('Access denied.');
 if (TYPO3_MODE == 'BE') {
     // register rnbase dispatcher for modules before the extbase dispatcher
     if (!tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
-        tx_rnbase::load('Tx_Rnbase_Backend_ModuleRunner');
         $GLOBALS['TBE_MODULES']['_dispatcher'] = array_merge(
             ['Tx_Rnbase_Backend_ModuleRunner'],
             (array) $GLOBALS['TBE_MODULES']['_dispatcher']

--- a/maps/class.tx_rnbase_maps_BaseMap.php
+++ b/maps/class.tx_rnbase_maps_BaseMap.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_maps_IMap');
-tx_rnbase::load('tx_rnbase_maps_TypeRegistry');
 
 /**
  * Common Interface for Maps.

--- a/maps/class.tx_rnbase_maps_Factory.php
+++ b/maps/class.tx_rnbase_maps_Factory.php
@@ -39,7 +39,6 @@ class tx_rnbase_maps_Factory
         $map = self::createMap('tx_rnbase_maps_google_Map', $configurations, $confId);
         $keys = $configurations->getKeyNames($confId.'poi.');
         if (isset($keys)) {
-            tx_rnbase::load('tx_rnbase_maps_Util');
             foreach ($keys as $key) {
                 $poi = $configurations->get($confId.'poi.'.$key.'.');
                 $poi = tx_rnbase::makeInstance('tx_rnbase_maps_POI', $poi);

--- a/maps/class.tx_rnbase_maps_POI.php
+++ b/maps/class.tx_rnbase_maps_POI.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_maps_ILocation');
-tx_rnbase::load('tx_rnbase_maps_Coord');
 
 /**
  * Implementation for a POI with description. Useful to mark a point in a map.

--- a/maps/class.tx_rnbase_maps_Util.php
+++ b/maps/class.tx_rnbase_maps_Util.php
@@ -99,7 +99,6 @@ class tx_rnbase_maps_Util
         if (!self::hasGeoData($item)) {
             return false;
         }
-        tx_rnbase::load('tx_rnbase_maps_DefaultMarker');
 
         $marker = new tx_rnbase_maps_DefaultMarker();
         if ($item->getLongitude() || $item->getLatitude()) {

--- a/maps/google/class.tx_rnbase_maps_google_Map.php
+++ b/maps/google/class.tx_rnbase_maps_google_Map.php
@@ -22,10 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_maps_BaseMap');
-tx_rnbase::load('tx_rnbase_util_Extensions');
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 if (!tx_rnbase_util_Extensions::isLoaded('wec_map')) {
     throw new Exception('Extension wec_map must be installed to use GoogleMaps!');
 }

--- a/maps/google/class.tx_rnbase_maps_google_Util.php
+++ b/maps/google/class.tx_rnbase_maps_google_Util.php
@@ -22,11 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_maps_BaseMap');
-tx_rnbase::load('tx_rnbase_util_Extensions');
-tx_rnbase::load('tx_rnbase_util_Strings');
-tx_rnbase::load('tx_rnbase_util_Logger');
-
 /**
  * .
  */

--- a/mod/base/class.tx_rnbase_mod_base_Lister.php
+++ b/mod/base/class.tx_rnbase_mod_base_Lister.php
@@ -505,7 +505,6 @@ abstract class tx_rnbase_mod_base_Lister
      */
     protected function showFreeTextSearchForm(&$marker, $key, array $options = [])
     {
-        tx_rnbase::load('tx_rnbase_mod_Util');
         $searchstring = tx_rnbase_mod_Util::getModuleValue($key, $this->getModule(), [
             'changed' => Tx_Rnbase_Utility_T3General::_GP('SET'),
         ]);
@@ -523,7 +522,6 @@ abstract class tx_rnbase_mod_base_Lister
             0 => $GLOBALS['LANG']->getLL('label_select_hide_hidden'),
             1 => $GLOBALS['LANG']->getLL('label_select_show_hidden'),
         ];
-        tx_rnbase::load('tx_rnbase_mod_Util');
         $selectedItem = tx_rnbase_mod_Util::getModuleValue('showhidden', $this->getModule(), [
             'changed' => Tx_Rnbase_Utility_T3General::_GP('SET'),
         ]);

--- a/mod/class.tx_rnbase_mod_BaseModFunc.php
+++ b/mod/class.tx_rnbase_mod_BaseModFunc.php
@@ -22,11 +22,8 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 abstract class tx_rnbase_mod_BaseModFunc implements tx_rnbase_mod_IModFunc
 {

--- a/mod/class.tx_rnbase_mod_BaseModule.php
+++ b/mod/class.tx_rnbase_mod_BaseModule.php
@@ -23,14 +23,8 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility_Icons');
-tx_rnbase::load('Tx_Rnbase_Backend_Module_Base');
-tx_rnbase::load('Tx_Rnbase_Utility_T3General');
 
 /**
  * Fertige Implementierung eines BE-Moduls. Das Modul ist dabei nur eine Hülle für die einzelnen Modulfunktionen.
@@ -252,9 +246,6 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
     public function getConfigurations()
     {
         if (!$this->configurations) {
-            tx_rnbase::load('tx_rnbase_util_Misc');
-            tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-
             tx_rnbase_util_Misc::prepareTSFE(); // Ist bei Aufruf aus BE notwendig!
             $cObj = tx_rnbase_util_TYPO3::getContentObject();
 
@@ -264,7 +255,6 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
 
             $userTSconfig = $GLOBALS['BE_USER']->getTSConfig('mod.'.$this->getExtensionKey().'.');
             if (!empty($userTSconfig['properties'])) {
-                tx_rnbase::load('tx_rnbase_util_Arrays');
                 $pageTSconfig = tx_rnbase_util_Arrays::mergeRecursiveWithOverrule($pageTSconfig, $userTSconfig['properties']);
             }
 
@@ -319,8 +309,6 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
         $this->content .= $this->getDoc()->endPage();
 
         $params = $markerArray = $subpartArray = $wrappedSubpartArray = [];
-        tx_rnbase::load('tx_rnbase_util_BaseMarker');
-        tx_rnbase::load('tx_rnbase_util_Templates');
         tx_rnbase_util_BaseMarker::callModules($this->content, $markerArray, $subpartArray, $wrappedSubpartArray, $params, $this->getConfigurations()->getFormatter());
         $content = tx_rnbase_util_Templates::substituteMarkerArrayCached($this->content, $markerArray, $subpartArray, $wrappedSubpartArray);
 

--- a/mod/class.tx_rnbase_mod_ExtendedModFunc.php
+++ b/mod/class.tx_rnbase_mod_ExtendedModFunc.php
@@ -22,11 +22,8 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 /**
  * ModFunc mit SubSelector und SubMenu.

--- a/mod/class.tx_rnbase_mod_Util.php
+++ b/mod/class.tx_rnbase_mod_Util.php
@@ -22,8 +22,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility_Icons');
 
 class tx_rnbase_mod_Util
 {

--- a/model/class.tx_rnbase_model_base.php
+++ b/model/class.tx_rnbase_model_base.php
@@ -22,11 +22,8 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_model_data');
 tx_rnbase::load('Tx_Rnbase_Domain_Model_RecordInterface');
-tx_rnbase::load('tx_rnbase_util_TCA');
 // Die Datenbank-Klasse
-tx_rnbase::load('tx_rnbase_util_DB');
 
 /**
  * Basisklasse für die meisten Model-Klassen. Sie stellt einen Konstruktor bereit, der sowohl
@@ -166,7 +163,6 @@ class tx_rnbase_model_base extends tx_rnbase_model_data implements Tx_Rnbase_Dom
             $field = tx_rnbase_util_TCA::getCrdateFieldForTable($tableName);
             if (!$this->isPropertyEmpty($field)) {
                 $tstamp = (int) $this->getProperty($field);
-                tx_rnbase::load('tx_rnbase_util_Dates');
                 $datetime = tx_rnbase_util_Dates::getDateTime('@'.$tstamp);
             }
         }
@@ -187,7 +183,6 @@ class tx_rnbase_model_base extends tx_rnbase_model_data implements Tx_Rnbase_Dom
             $field = tx_rnbase_util_TCA::getTstampFieldForTable($tableName);
             if (!$this->isPropertyEmpty($field)) {
                 $tstamp = (int) $this->getProperty($field);
-                tx_rnbase::load('tx_rnbase_util_Dates');
                 $datetime = tx_rnbase_util_Dates::getDateTime('@'.$tstamp);
             }
         }

--- a/model/class.tx_rnbase_model_data.php
+++ b/model/class.tx_rnbase_model_data.php
@@ -229,8 +229,6 @@ class tx_rnbase_model_data implements Tx_Rnbase_Domain_Model_DataInterface, Iter
      */
     protected function underscore($string)
     {
-        tx_rnbase::load('tx_rnbase_util_Strings');
-
         return tx_rnbase_util_Strings::camelCaseToLowerCaseUnderscored($string);
     }
 

--- a/model/class.tx_rnbase_model_media.php
+++ b/model/class.tx_rnbase_model_media.php
@@ -23,7 +23,6 @@
  ***************************************************************/
 
 // Die Datenbank-Klasse
-tx_rnbase::load('tx_rnbase_model_base');
 
 class tx_rnbase_model_media extends tx_rnbase_model_base
 {

--- a/tests/Classes/Backend/Utility/IconsTest.php
+++ b/tests/Classes/Backend/Utility/IconsTest.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility_Icons');
 
 /**
  * Tx_Rnbase_Backend_Utility_IconsTest.

--- a/tests/Classes/Backend/UtilityTest.php
+++ b/tests/Classes/Backend/UtilityTest.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
 
 /**
  * tx_rnbase_tests_controller_testcase.

--- a/tests/Classes/Database/TreeQueryBuilderTest.php
+++ b/tests/Classes/Database/TreeQueryBuilderTest.php
@@ -424,7 +424,6 @@ class Tx_Rnbase_Database_TreeQueryBuilderTest extends tx_rnbase_tests_BaseTestCa
      */
     protected function getTreeQueryBuilderMock($expectFunc)
     {
-        tx_rnbase::load('Tx_Rnbase_Database_Connection');
         $connection = $this->getMock(
             'Tx_Rnbase_Database_Connection',
             get_class_methods('Tx_Rnbase_Database_Connection')
@@ -432,7 +431,6 @@ class Tx_Rnbase_Database_TreeQueryBuilderTest extends tx_rnbase_tests_BaseTestCa
 
         $expectFunc($connection);
 
-        tx_rnbase::load('Tx_Rnbase_Database_TreeQueryBuilder');
         $treeQueryBuildMock = $this->getMock(
             'Tx_Rnbase_Database_TreeQueryBuilder',
             ['getConnection']

--- a/tests/Classes/Domain/Collection/BaseTest.php
+++ b/tests/Classes/Domain/Collection/BaseTest.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Domain_Collection_Base');
 
 /**
  * collection unit tests.

--- a/tests/Classes/Domain/Model/BaseTest.php
+++ b/tests/Classes/Domain/Model/BaseTest.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Domain_Model_Base');
 
 class Tx_Rnbase_Domain_Model_BaseTest extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/Classes/Domain/Model/DataTest.php
+++ b/tests/Classes/Domain/Model/DataTest.php
@@ -23,7 +23,6 @@
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Domain_Model_Data');
 
 /**
  * Data model unit tests.

--- a/tests/Classes/Domain/Repository/AbstractRepositoryTest.php
+++ b/tests/Classes/Domain/Repository/AbstractRepositoryTest.php
@@ -22,8 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Domain_Repository_AbstractRepository');
-
 /**
  * Test for abstract repository.
  *

--- a/tests/Classes/Domain/Repository/PersistenceRepositoryTest.php
+++ b/tests/Classes/Domain/Repository/PersistenceRepositoryTest.php
@@ -62,7 +62,6 @@ class Tx_Rnbase_Domain_Repository_PersistenceRepositoryTest extends tx_rnbase_te
      */
     public function testIsModelWrapperClassWithRightClass()
     {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Base');
         self::assertTrue(
             $this->callInaccessibleMethod(
                 $this->getRepository(),
@@ -287,15 +286,12 @@ class Tx_Rnbase_Domain_Repository_PersistenceRepositoryTest extends tx_rnbase_te
     protected function getRepository(
         array $methods = []
     ) {
-        tx_rnbase::load('Tx_Rnbase_Database_Connection');
         $connection = $this->getMock(
             'Tx_Rnbase_Database_Connection',
             get_class_methods('Tx_Rnbase_Database_Connection')
         );
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Base');
         $model = $this->getModel(null, 'Tx_Rnbase_Domain_Model_Base');
 
-        tx_rnbase::load('Tx_Rnbase_Domain_Repository_PersistenceRepository');
         $repo = $this->getMockForAbstractClass(
             'Tx_Rnbase_Domain_Repository_PersistenceRepository',
             [],

--- a/tests/Classes/Frontend/Filter/Utility/CategoryTest.php
+++ b/tests/Classes/Frontend/Filter/Utility/CategoryTest.php
@@ -27,8 +27,6 @@ use Sys25\RnBase\Frontend\Request\Parameters;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-\tx_rnbase::load('Tx_Rnbase_Category_SearchUtility');
-\tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
 
 /**
  * Tx_Rnbase_Category_FilterUtilityTest.

--- a/tests/Classes/Utility/CryptTest.php
+++ b/tests/Classes/Utility/CryptTest.php
@@ -23,7 +23,6 @@
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Utility_Crypt');
 
 /**
  * Mcrypt.

--- a/tests/Classes/Utility/MailTest.php
+++ b/tests/Classes/Utility/MailTest.php
@@ -26,7 +26,6 @@ use Sys25\RnBase\Utility\TYPO3;
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Utility_Mail');
 
 /**
  * Mcrypt.

--- a/tests/Classes/Utility/TcaToolTest.php
+++ b/tests/Classes/Utility/TcaToolTest.php
@@ -21,7 +21,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
-tx_rnbase::load('Tx_Rnbase_Utility_TcaTool');
 
 /**
  * Tx_Rnbase_Utility_TcaToolTest.

--- a/tests/Classes/Utility/TypoScriptTest.php
+++ b/tests/Classes/Utility/TypoScriptTest.php
@@ -23,7 +23,6 @@
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Utility_Crypt');
 
 /**
  * Mcrypt.

--- a/tests/action/class.tx_rnbase_tests_action_BaseIOC_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_BaseIOC_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_action_BaseIOC');
 
 /**
  * tx_rnbase_tests_action_BaseIOC_testcase.

--- a/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_action_CacheHandlerDefault');
 
 /**
  * tests for tx_rnbase_util_Templates.

--- a/tests/class.tx_rnbase_tests_BaseTestCase.php
+++ b/tests/class.tx_rnbase_tests_BaseTestCase.php
@@ -23,7 +23,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
 // make sure to load the constants
 require_once tx_rnbase_util_Extensions::extPath('rn_base').'Classes/Constants.php';
 
@@ -244,7 +243,6 @@ abstract class tx_rnbase_tests_BaseTestCase extends \PHPUnit\Framework\TestCase
     {
         // there is no array, so convert the yaml content or file
         if ($tryToLoadYamlFile && !is_array($data)) {
-            tx_rnbase::load('tx_rnbase_util_Spyc');
             $data = tx_rnbase_util_Spyc::YAMLLoad($data);
         }
 

--- a/tests/class.tx_rnbase_tests_Logger_testcase.php
+++ b/tests/class.tx_rnbase_tests_Logger_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Logger');
-
 class tx_rnbase_tests_Logger_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testLogger()

--- a/tests/class.tx_rnbase_tests_basemarker_testcase.php
+++ b/tests/class.tx_rnbase_tests_basemarker_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-
 class tx_rnbase_tests_basemarker_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testContainsMarker()

--- a/tests/class.tx_rnbase_tests_cache_testcase.php
+++ b/tests/class.tx_rnbase_tests_cache_testcase.php
@@ -22,13 +22,10 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-
 class tx_rnbase_tests_cache_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testCacheManager()
     {
-        tx_rnbase::load('tx_rnbase_cache_Manager');
         $cache = tx_rnbase_cache_Manager::getCache('__rnbaseMgrCache__');
         $this->assertTrue(is_object($cache), 'No Cache instanciated');
     }

--- a/tests/class.tx_rnbase_tests_calendar_testcase.php
+++ b/tests/class.tx_rnbase_tests_calendar_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Calendar');
-
 class tx_rnbase_tests_calendar_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testCalendar()

--- a/tests/class.tx_rnbase_tests_configurations_testcase.php
+++ b/tests/class.tx_rnbase_tests_configurations_testcase.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
 
 class tx_rnbase_tests_configurations_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/class.tx_rnbase_tests_controller_testcase.php
+++ b/tests/class.tx_rnbase_tests_controller_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_controller');
-tx_rnbase::load('tx_rnbase_exception_IHandler');
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
 
 class tx_rnbase_dummyController extends tx_rnbase_controller

--- a/tests/class.tx_rnbase_tests_listbuilder_testcase.php
+++ b/tests/class.tx_rnbase_tests_listbuilder_testcase.php
@@ -22,9 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-
 class tx_rnbase_tests_listbuilder_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function setup()
@@ -130,7 +127,6 @@ class tx_rnbase_tests_listbuilder_testcase extends tx_rnbase_tests_BaseTestCase
     private function getModels()
     {
         $models = [];
-        tx_rnbase::load('tx_rnbase_model_media');
         $models[] = new tx_rnbase_model_media(['uid' => 22, 'file_name' => 'file22.jpg']);
         $models[] = new tx_rnbase_model_media(['uid' => 33, 'file_name' => 'file33.jpg']);
 

--- a/tests/class.tx_rnbase_tests_misc_testcase.php
+++ b/tests/class.tx_rnbase_tests_misc_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-
 class tx_rnbase_dummyMisc extends tx_rnbase_util_Misc
 {
     public static function callGetErrorMailHtml($e, $actionName)

--- a/tests/class.tx_rnbase_tests_rnbase_testcase.php
+++ b/tests/class.tx_rnbase_tests_rnbase_testcase.php
@@ -49,7 +49,6 @@ class tx_rnbase_tests_rnbase_testcase extends tx_rnbase_tests_BaseTestCase
 
     private function isExtBasePossible()
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         // TODO: bessere Testklasse finden
         return false && tx_rnbase_util_TYPO3::isExtLoaded('extbase') &&
             tx_rnbase_util_TYPO3::isExtMinVersion('t3sponsors', 2001);

--- a/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
+++ b/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
@@ -27,7 +27,6 @@
 /*
  * benötigte Klassen einbinden.
  */
-tx_rnbase::load('tx_rnbase_mod_IDecorator');
 
 /**
  * Diese Klasse ist für die Darstellung von Elementen im Backend verantwortlich.

--- a/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
+++ b/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
@@ -22,9 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_mod_Tables');
-tx_rnbase::load('tx_rnbase_util_FormTool');
-
 class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
 {
     /**

--- a/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
+++ b/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
@@ -22,7 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  */
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_data');
 
 /**
  * tests for tx_rnbase_mod_linker_ShowDetails.

--- a/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_base');
 
 class tx_rnbase_tests_model_Base_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_data');
 
 /**
  * @author Michael Wagner <michael.wagner@dmk-ebusiness.de>

--- a/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_model_media');
-
 /**
  * @author Hannes Bochmann <hannes.bochmann@dmk-business.de>
  */

--- a/tests/util/class.tx_rnbase_tests_util_DB_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_DB_testcase.php
@@ -22,10 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_DB');
-tx_rnbase::load('tx_rnbase_util_SearchBase');
-tx_rnbase::load('Tx_Rnbase_Database_Connection');
-
 class tx_rnbase_tests_util_DB_testcase extends tx_rnbase_tests_BaseTestCase
 {
     /**

--- a/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Dates');
-
 class tx_rnbase_tests_util_Dates_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testDatetimeGetTimeStamp()

--- a/tests/util/class.tx_rnbase_tests_util_Extensions_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Extensions_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Extensions');
 
 /**
  * tx_rnbase_tests_util_Extensions_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Files_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Files_testcase.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Files');
 
 /**
  * tx_rnbase_tests_util_Files_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Lock');
 
 /**
  * Basis Testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Network_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Network_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Network');
 
 /**
  * tx_rnbase_tests_util_Network_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_PageBrowser');
 
 class tx_rnbase_tests_util_PageBrowser_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_DB');
-
 class tx_rnbase_tests_util_SearchBase_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testSearchFieldJoinedWithoutValue()

--- a/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_SimpleMarker');
 tx_rnbase::load('tx_rnbase_util_TS');
 
 class tx_rnbase_util_SimpleMarkerTests extends tx_rnbase_util_SimpleMarker

--- a/tests/util/class.tx_rnbase_tests_util_Spyc_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Spyc_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Spyc');
 
 /**
  * @author Rene Nitzsche <rene@system25.de>

--- a/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Strings');
 
 /**
  * @author Rene Nitzsche <rene@system25.de>

--- a/tests/util/class.tx_rnbase_tests_util_TCA_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_TCA_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_TCA');
 
 /**
  * tx_rnbase_tests_util_TCA Tests.

--- a/tests/util/class.tx_rnbase_tests_util_TYPO3_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_TYPO3_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TCA');
-
 /**
  * @author Hannes Bochmann <hannes.bochmann@dmk-business.de>
  */

--- a/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
@@ -25,9 +25,7 @@
 use TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 /**
  * tests for tx_rnbase_util_Templates.

--- a/util/class.tx_rnbase_util_Arrays.php
+++ b/util/class.tx_rnbase_util_Arrays.php
@@ -58,7 +58,6 @@ class tx_rnbase_util_Arrays
     private static function toHashArray($mixed, $splitCharacters = ',;:\s')
     {
         if (is_string($mixed)) {
-            tx_rnbase::load('tx_rnbase_util_Misc');
             $array = tx_rnbase_util_Misc::explode($mixed, $splitCharacters); // TODO: Enable empty values by defining a better explode functions.
             for ($i = 0, $len = count($array); $i < $len; $i = $i + 2) {
                 $hashArray[$array[$i]] = $array[$i + 1];

--- a/util/class.tx_rnbase_util_BEPager.php
+++ b/util/class.tx_rnbase_util_BEPager.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_FormTool');
-
 /**
  * Pager für BE-Module.
  */

--- a/util/class.tx_rnbase_util_BaseMarker.php
+++ b/util/class.tx_rnbase_util_BaseMarker.php
@@ -22,10 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-tx_rnbase::load('tx_rnbase_util_Templates');
-tx_rnbase::load('Tx_Rnbase_Frontend_Marker_BaseMarker');
-
 /**
  * Base class for Markers.
  */
@@ -140,7 +136,6 @@ class tx_rnbase_util_BaseMarker extends Tx_Rnbase_Frontend_Marker_BaseMarker
             }
         }
         if ($minfo) {
-            tx_rnbase::load('tx_rnbase_util_Debug');
             $record['__MINFO'] = tx_rnbase_util_Debug::viewArray($minfoArr);
         }
 

--- a/util/class.tx_rnbase_util_Dates.php
+++ b/util/class.tx_rnbase_util_Dates.php
@@ -21,7 +21,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Strings');
 
 /**
  * Simple Utility methods for date conversion.

--- a/util/class.tx_rnbase_util_Debug.php
+++ b/util/class.tx_rnbase_util_Debug.php
@@ -24,8 +24,6 @@
 
 use TYPO3\CMS\Core\Utility\DebugUtility;
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-
 /**
  * Encapsulate debug functionality of TYPO3 for backward compatibility.
  */
@@ -110,7 +108,6 @@ class tx_rnbase_util_Debug
     {
         static $debugKey = null;
         if (null === $debugKey) {
-            tx_rnbase::load('Tx_Rnbase_Configuration_Processor');
             $debugKey = Tx_Rnbase_Configuration_Processor::getExtensionCfgValue('rn_base', 'debugKey');
         }
         if (empty($debugKey)) {

--- a/util/class.tx_rnbase_util_Files.php
+++ b/util/class.tx_rnbase_util_Files.php
@@ -68,7 +68,6 @@ class tx_rnbase_util_Files
                 $ret = @file_get_contents($fullPath);
                 $subpart = isset($options['subpart']) ? $options['subpart'] : '';
                 if ($subpart) {
-                    tx_rnbase::load('tx_rnbase_util_Templates');
                     $ret = tx_rnbase_util_Templates::getSubpart($ret, $subpart);
                 }
             }
@@ -194,7 +193,6 @@ class tx_rnbase_util_Files
     {
         $cleaned = $name;
         if (function_exists('iconv')) {
-            tx_rnbase::load('tx_rnbase_util_Strings');
             $charset = tx_rnbase_util_Strings::isUtf8String($cleaned) ? 'UTF-8' : 'ISO-8859-1';
             $oldLocal = setlocale(LC_ALL, 0);
             setlocale(LC_ALL, 'de_DE@euro', 'de_DE', 'deu_deu', 'de', 'ge');
@@ -218,7 +216,6 @@ class tx_rnbase_util_Files
     public static function makeZipFile($files = [], $destination = '', $overwrite = false)
     {
         if (!extension_loaded('zip')) {
-            tx_rnbase::load('tx_rnbase_util_Logger');
             tx_rnbase_util_Logger::warn('PHP zip extension not loaded!', 'rn_base');
 
             return false;

--- a/util/class.tx_rnbase_util_FormTool.php
+++ b/util/class.tx_rnbase_util_FormTool.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('Tx_Rnbase_Backend_Form_ToolBox');
 
 /**
  * Diese Klasse stellt hilfreiche Funktionen zur Erstellung von Formularen

--- a/util/class.tx_rnbase_util_FormatUtil.php
+++ b/util/class.tx_rnbase_util_FormatUtil.php
@@ -21,7 +21,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Strings');
 
 /**
  * Contains utility functions for formatting

--- a/util/class.tx_rnbase_util_Json.php
+++ b/util/class.tx_rnbase_util_Json.php
@@ -95,8 +95,6 @@ define('SERVICES_JSON_LOOSE_TYPE', 16);
  */
 define('SERVICES_JSON_SUPPRESS_ERRORS', 32);
 
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 /**
  * Converts to and from JSON format.
  *

--- a/util/class.tx_rnbase_util_Lang.php
+++ b/util/class.tx_rnbase_util_Lang.php
@@ -21,7 +21,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Files');
 
 /**
  * Wrapper for language usage.
@@ -131,7 +130,6 @@ class tx_rnbase_util_Lang
         }
         //new values from the given array are added to the existing local lang.
         //existing values in the local lang are overruled with those of the given array.
-        tx_rnbase::load('tx_rnbase_util_Arrays');
         $this->LOCAL_LANG = tx_rnbase_util_Arrays::mergeRecursiveWithOverrule(
             is_array($this->LOCAL_LANG) ? $this->LOCAL_LANG : [],
             $langArr

--- a/util/class.tx_rnbase_util_Link.php
+++ b/util/class.tx_rnbase_util_Link.php
@@ -27,7 +27,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-tx_rnbase::load('tx_rnbase_util_Network');
 
 /**
  * This class is a wrapper around \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::typoLink.
@@ -525,7 +524,6 @@ class tx_rnbase_util_Link
     public function redirect($httpStatus = null)
     {
         session_write_close();
-        tx_rnbase::load('tx_rnbase_util_Network');
         tx_rnbase_util_Network::redirect($this->makeUrl(false), $httpStatus);
     }
 
@@ -546,7 +544,6 @@ class tx_rnbase_util_Link
         $this->parameters = is_array($this->parameters) ? $this->parameters : [];
         $this->overruledParameters = is_array($this->overruledParameters) ? $this->overruledParameters : [];
         unset($this->overruledParameters['DATA']);
-        tx_rnbase::load('tx_rnbase_util_Arrays');
         $parameters = tx_rnbase_util_Arrays::mergeRecursiveWithOverrule(
             $this->overruledParameters,
             $this->parameters

--- a/util/class.tx_rnbase_util_ListBuilder.php
+++ b/util/class.tx_rnbase_util_ListBuilder.php
@@ -21,10 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_ListBuilderInfo');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
 tx_rnbase::load('tx_rnbase_util_IListProvider');
-tx_rnbase::load('tx_rnbase_util_Debug');
 
 /**
  * Generic List-Builder. Creates a list of data with Pagebrowser.

--- a/util/class.tx_rnbase_util_ListMarker.php
+++ b/util/class.tx_rnbase_util_ListMarker.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_ListMarkerInfo');
-
 /**
  * Base class for Markers.
  */

--- a/util/class.tx_rnbase_util_Lock.php
+++ b/util/class.tx_rnbase_util_Lock.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Files');
-
 /**
  * Util to handle locking of processes.
  *
@@ -201,7 +199,6 @@ class tx_rnbase_util_Lock
             tx_rnbase_util_Files::mkdir_deep(dirname($fileName));
         }
         if (!tx_rnbase_util_Files::writeFile($fileName, time(), true)) {
-            tx_rnbase::load('tx_rnbase_util_Logger');
             tx_rnbase_util_Logger::warn(
                 'Lock file could not be created for "'.$this->getName().'" process!',
                 'rn_base',

--- a/util/class.tx_rnbase_util_Mail.php
+++ b/util/class.tx_rnbase_util_Mail.php
@@ -22,10 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-tx_rnbase::load('tx_rnbase_util_Logger');
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 /**
  * Encapsulate simple mailing functionality of TYPO3 for backward compatibility.
  *

--- a/util/class.tx_rnbase_util_MediaMarker.php
+++ b/util/class.tx_rnbase_util_MediaMarker.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_SimpleMarker');
-
 if (tx_rnbase_util_Extensions::isLoaded('dam')) {
     require_once tx_rnbase_util_Extensions::extPath('dam').'lib/class.tx_dam_db.php';
 }

--- a/util/class.tx_rnbase_util_PageBrowser.php
+++ b/util/class.tx_rnbase_util_PageBrowser.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Math');
-
 /**
  * Contains utility functions for HTML-Forms.
  */

--- a/util/class.tx_rnbase_util_PageBrowserMarker.php
+++ b/util/class.tx_rnbase_util_PageBrowserMarker.php
@@ -22,10 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_PageBrowser');
-tx_rnbase::load('tx_rnbase_util_Math');
-
 /**
  * Contains utility functions for HTML-Forms.
  */

--- a/util/class.tx_rnbase_util_SearchGeneric.php
+++ b/util/class.tx_rnbase_util_SearchGeneric.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_SearchBase');
-
 /**
  * Generic search class. All parameters will be configured.
  *

--- a/util/class.tx_rnbase_util_SimpleMarker.php
+++ b/util/class.tx_rnbase_util_SimpleMarker.php
@@ -22,9 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('Tx_Rnbase_Frontend_Marker_Utility');
-
 /**
  * A generic marker class.
  *

--- a/util/class.tx_rnbase_util_TCA.php
+++ b/util/class.tx_rnbase_util_TCA.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_model_data');
-
 /**
  * TODO: extend from Tx_Rnbase_Util_TCA.
  *
@@ -208,8 +206,6 @@ class tx_rnbase_util_TCA
      */
     public static function loadTCA($tablename)
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
-
         if (tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
             if (TYPO3_MODE === 'FE' && isset($_REQUEST['eID'])) {
                 $eidUtility = tx_rnbase_util_Typo3Classes::getEidUtilityClass();
@@ -324,7 +320,6 @@ class tx_rnbase_util_TCA
         // check eval list
         if (!empty($config['eval'])) {
             // check eval list
-            tx_rnbase::load('tx_rnbase_util_Strings');
             $evalList = tx_rnbase_util_Strings::trimExplode(
                 ',',
                 $config['eval'],
@@ -364,7 +359,6 @@ class tx_rnbase_util_TCA
         $columns = empty($GLOBALS['TCA'][$tableName]['columns']) ? [] : $GLOBALS['TCA'][$tableName]['columns'];
         $tcaOverrides = $options->getTcaOverrides();
         if (!empty($tcaOverrides['columns'])) {
-            tx_rnbase::load('tx_rnbase_util_Arrays');
             $columns = tx_rnbase_util_Arrays::mergeRecursiveWithOverrule(
                 $columns,
                 $tcaOverrides['columns']
@@ -392,8 +386,6 @@ class tx_rnbase_util_TCA
         if (!is_array($needle)) {
             return [];
         }
-
-        tx_rnbase::load('tx_rnbase_util_Arrays');
 
         return tx_rnbase_util_Arrays::removeNotIn($data, $needle);
     }

--- a/util/class.tx_rnbase_util_TS.php
+++ b/util/class.tx_rnbase_util_TS.php
@@ -21,8 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Utility_TypoScript');
-
 /**
  * Contains utility functions for TypoScript.
  *

--- a/util/class.tx_rnbase_util_TSDAM.php
+++ b/util/class.tx_rnbase_util_TSDAM.php
@@ -30,10 +30,6 @@ if (tx_rnbase_util_Extensions::isLoaded('dam')) {
 
 define('DEFAULT_LOCAL_FIELD', '_LOCALIZED_UID');
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 /**
  * Contains utility functions for DAM.
  */
@@ -222,7 +218,6 @@ class tx_rnbase_util_TSDAM
      */
     public static function isVersion10()
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         $version = tx_rnbase_util_TYPO3::getExtVersion('dam');
         if (preg_match('(\d*\.\d*\.\d)', $version, $versionArr)) {
             $version = $versionArr[0];

--- a/util/class.tx_rnbase_util_TSFAL.php
+++ b/util/class.tx_rnbase_util_TSFAL.php
@@ -27,9 +27,6 @@ use TYPO3\CMS\Core\Resource\FileReference;
 
 define('DEFAULT_LOCAL_FIELD', '_LOCALIZED_UID');
 
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 /**
  * Contains utility functions for FAL.
  */
@@ -75,7 +72,6 @@ class tx_rnbase_util_TSFAL
      */
     public function printImages($content, $tsConf)
     {
-        tx_rnbase::load('tx_rnbase_util_Templates');
         $conf = $this->createConf($tsConf);
         $file = $conf->get('template');
         $file = $file ? $file : 'EXT:rn_base/res/simplegallery.html';
@@ -159,7 +155,6 @@ class tx_rnbase_util_TSFAL
         /* @var $fileRepository \TYPO3\CMS\Core\Resource\FileRepository */
         $fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
         $pics = [];
-        tx_rnbase::load('tx_rnbase_util_Strings');
         // Getting the files
         // Try DAM style
         if ($conf->get($confId.'refTable')) {

--- a/util/class.tx_rnbase_util_XmlElement.php
+++ b/util/class.tx_rnbase_util_XmlElement.php
@@ -118,7 +118,6 @@ class tx_rnbase_util_XmlElement extends SimpleXMLElement
     public function getDateTimeFromPath($path)
     {
         $date = $this->getValueFromPath($path);
-        tx_rnbase::load('tx_rnbase_util_Dates');
         $date = tx_rnbase_util_Dates::getDateTime($date);
 
         return $date;

--- a/util/db/class.tx_rnbase_util_db_Exception.php
+++ b/util/db/class.tx_rnbase_util_db_Exception.php
@@ -22,7 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Exception');
 /**
  * Default exception class.
  */

--- a/util/db/class.tx_rnbase_util_db_MsSQL.php
+++ b/util/db/class.tx_rnbase_util_db_MsSQL.php
@@ -21,7 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_db_Exception');
 tx_rnbase::load('tx_rnbase_util_db_IDatabase');
 
 /**

--- a/util/db/class.tx_rnbase_util_db_MySQL.php
+++ b/util/db/class.tx_rnbase_util_db_MySQL.php
@@ -22,7 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_db_Exception');
 tx_rnbase::load('tx_rnbase_util_db_IDatabase');
 
 /**


### PR DESCRIPTION
This fixes PHPStan errors in extensions that use rn_base.

In addition, this also should slightly improve performance as classes
now are loaded on demand more often.