### PR TITLE
[BUGFIX] Remove manual autoloading of autoloadable classes

### DIFF
--- a/Classes/Backend/Form/ToolBox.php
+++ b/Classes/Backend/Form/ToolBox.php
@@ -229,7 +229,6 @@ class ToolBox
                 ' title="'.$label.'\" alt="" >';
         }
         if ($options['sprite']) {
-            tx_rnbase::load('tx_rnbase_mod_Util');
             $label = tx_rnbase_mod_Util::getSpriteIcon($options['sprite']);
         }
         $jsCode = BackendUtility::viewOnClick($pid, '', '', '', '', $urlParams);

--- a/Classes/Backend/Lister/AbstractLister.php
+++ b/Classes/Backend/Lister/AbstractLister.php
@@ -310,8 +310,6 @@ abstract class AbstractLister
     public function renderTemplate(
         $template
     ) {
-        tx_rnbase::load('tx_rnbase_util_Templates');
-
         return tx_rnbase_util_Templates::substituteMarkerArrayCached(
             $template,
             $this->renderListMarkers()

--- a/Classes/Backend/Utility/TcaTool.php
+++ b/Classes/Backend/Utility/TcaTool.php
@@ -98,7 +98,6 @@ class TcaTool
      * Add a wizard to column.
      * Usage:.
      *
-     * tx_rnbase::load('Tx_Rnbase_Util_TCA');
      * $tca = new Tx_Rnbase_Util_TCA();
      * $tca->addWizard($tcaTableArray, 'teams', 'add', 'wizard_add', array());
      *

--- a/Classes/Database/Connection.php
+++ b/Classes/Database/Connection.php
@@ -469,7 +469,6 @@ class Connection implements SingletonInterface
         // the connection has to be reconected after cache load,
         // so only the credentials are stored in cache, but this is critical,
         // so the cache was removed for the moment!
-//        tx_rnbase::load('tx_rnbase_cache_Manager');
 //        $cache = tx_rnbase_cache_Manager::getCache('rnbase_databases');
 //        $db = $cache->get('db_' . $key);
 //        if (!$db) {

--- a/Classes/Maps/Google/Util.php
+++ b/Classes/Maps/Google/Util.php
@@ -29,9 +29,6 @@ use Sys25\RnBase\Utility\Logger;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-/**
- * .
- */
 class Util
 {
     /**

--- a/Classes/Maps/MapUtility.php
+++ b/Classes/Maps/MapUtility.php
@@ -104,7 +104,6 @@ class MapUtility
         if (!self::hasGeoData($item)) {
             return false;
         }
-        tx_rnbase::load('tx_rnbase_maps_DefaultMarker');
 
         $marker = new DefaultMarker();
         if ($item->getLongitude() || $item->getLatitude()) {

--- a/Classes/Search/SearchBase.php
+++ b/Classes/Search/SearchBase.php
@@ -763,7 +763,6 @@ abstract class SearchBase
                      */
                     if (isset($options[$optionName]) && !is_array($options[$optionName])) {
                         if (!in_array($optionName, ['override', 'force'])) {
-                            tx_rnbase::load('tx_rnbase_util_Logger');
                             tx_rnbase_util_Logger::warn(
                                 'Invalid configuration for config option "'.$optionName.'".',
                                 'rn_base',

--- a/Classes/Utility/Misc.php
+++ b/Classes/Utility/Misc.php
@@ -669,7 +669,6 @@ MAYDAYPAGE;
         $ignoreMailLock = (array_key_exists('ignoremaillock', $options) && $options['ignoremaillock']);
 
         if (!$ignoreMailLock) {
-            tx_rnbase::load('tx_rnbase_util_Lock');
             // Only one mail within one minute!
             $lock = tx_rnbase_util_Lock::getInstance('errormail', 60);
             if ($lock->isLocked()) {
@@ -710,7 +709,6 @@ MAYDAYPAGE;
         $textPart .= "Stacktrace:\n".$e->__toString()."\n";
         $textPart .= 'SITE_URL: '.self::getIndpEnv('TYPO3_SITE_URL')."\n";
 
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         $textPart .= 'BE_USER: '.TYPO3::getBEUserUID()."\n";
         $textPart .= 'FE_USER: '.TYPO3::getFEUserUID()."\n";
 
@@ -748,7 +746,6 @@ MAYDAYPAGE;
             }
         }
 
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         $htmlPart .= '<p><strong>BE_USER:</strong> '.TYPO3::getBEUserUID().'</p>';
         $htmlPart .= '<p><strong>FE_USER:</strong> '.TYPO3::getFEUserUID().'</p>';
 

--- a/Classes/Utility/TSFAL.php
+++ b/Classes/Utility/TSFAL.php
@@ -164,7 +164,6 @@ class TSFAL
         /* @var $fileRepository \TYPO3\CMS\Core\Resource\FileRepository */
         $fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
         $pics = [];
-        tx_rnbase::load('tx_rnbase_util_Strings');
         // Getting the files
         // Try DAM style
         if ($conf->get($confId.'refTable')) {

--- a/Documentation/cache_api.md
+++ b/Documentation/cache_api.md
@@ -6,7 +6,6 @@ TYPO3 hat mit der Version 4.3 eine eigene Cache-API eingeführt. Der Umgang dami
 rn_base schafft hier Abhilfe und bietet seit der Version 0.6.4 einen passenden Wrapper. Die Anwendung ist zunächst ganz einfach:
 
 ```php
-tx_rnbase::load('tx_rnbase_cache_Manager');
 $marker = tx_rnbase_cache_Manager::getCache('mycache')->get('tx_t3users_util_FEUserMarker');
 if(!$marker) {
   $marker = tx_rnbase::makeInstance('tx_t3users_util_FEUserMarker');
@@ -38,7 +37,6 @@ Weitere Infos gibt es im Web. Aber aufpassen, da sind einige Beispiele veraltet 
 Bei der Verwendung von rn_base kann man seinen Cache systemunabhängig registrieren. Die Cache-Manager-Klasse stellt dafür eine passende Methode bereit:
 
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
     tx_rnbase_cache_Manager::registerCache('your_cache_name',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_MEMCACHED,
@@ -52,7 +50,6 @@ Konkretes Beispiel für DB-basierten Cache
 -----------------------------------------
 Für mkforms wird ein Cache verwendet, um Session-Daten zu persistieren. Der Cache hat die ID mkforms. Mit folgender Config in der Datei typo3conf/localconf.php wird der Cache auf Datenbank-Basis eingerichtet:
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
     tx_rnbase_cache_Manager::registerCache('mkforms',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_T3DATABASE,
@@ -94,7 +91,6 @@ Konkretes Beispiel für MemCached
 So sollte es für memcached aussehen. Das ist aber noch ungetestet:
 
 ```php
-    tx_rnbase::load('tx_rnbase_cache_Manager');
     tx_rnbase_cache_Manager::registerCache('mkforms',
             tx_rnbase_cache_Manager::CACHE_FRONTEND_VARIABLE,
             tx_rnbase_cache_Manager::CACHE_BACKEND_MEMCACHED,
@@ -114,7 +110,7 @@ if (TYPO3_MODE == 'BE') {
         t3lib_cache::initializeCachingFramework();
         // State cache
         $GLOBALS['typo3CacheFactory']->create(
-                 'cf_mkmms', 
+                 'cf_mkmms',
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['frontend'],
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['backend'],
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mkmms']['options']

--- a/Legacy/action/class.tx_rnbase_action_BaseIOC.php
+++ b/Legacy/action/class.tx_rnbase_action_BaseIOC.php
@@ -139,7 +139,6 @@ abstract class tx_rnbase_action_BaseIOC
      */
     protected function addResources($configurations, $confId)
     {
-        tx_rnbase::load('tx_rnbase_util_Files');
         $pageRenderer = tx_rnbase_util_TYPO3::getPageRenderer();
 
         foreach ($this->getJavaScriptFilesByIncludePartConfId('includeJSFooter') as $javaScriptConfId => $file) {

--- a/Legacy/action/class.tx_rnbase_action_CacheHandlerDefault.php
+++ b/Legacy/action/class.tx_rnbase_action_CacheHandlerDefault.php
@@ -24,7 +24,6 @@ use Sys25\RnBase\Utility\Arrays;
  ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_action_ICacheHandler');
-tx_rnbase::load('tx_rnbase_cache_Manager');
 
 /**
  * A default CacheHandler.
@@ -190,7 +189,6 @@ class tx_rnbase_action_CacheHandlerDefault implements tx_rnbase_action_ICacheHan
     protected function getIcludeParams()
     {
         $params = $this->getConfigValue('include.params');
-        tx_rnbase::load('tx_rnbase_util_Strings');
 
         return tx_rnbase_util_Strings::trimExplode(',', $params, true);
     }

--- a/Legacy/action/class.tx_rnbase_action_CacheHandlerUser.php
+++ b/Legacy/action/class.tx_rnbase_action_CacheHandlerUser.php
@@ -21,10 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_action_CacheHandlerDefault');
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-tx_rnbase::load('tx_rnbase_cache_Manager');
-
 /**
  * Caching handler that saves data for feusers. For unregistered users the handler uses PHP-Session-ID
  * for identification.

--- a/Legacy/filter/class.tx_rnbase_filter_FilterItemMarker.php
+++ b/Legacy/filter/class.tx_rnbase_filter_FilterItemMarker.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-
 class tx_rnbase_filter_FilterItemMarker extends tx_rnbase_util_BaseMarker
 {
     public function parseTemplate($template, &$item, &$formatter, $confId, $marker = 'FILTERITEM')

--- a/Legacy/view/class.tx_rnbase_view_Base.php
+++ b/Legacy/view/class.tx_rnbase_view_Base.php
@@ -51,7 +51,6 @@ class tx_rnbase_view_Base
         $this->_init($configurations);
         $templateCode = tx_rnbase_util_Files::getFileResource($this->getTemplate($view, '.html'));
         if (!strlen($templateCode)) {
-            tx_rnbase::load('tx_rnbase_util_Misc');
             tx_rnbase_util_Misc::mayday('TEMPLATE NOT FOUND: '.$this->getTemplate($view, '.html'));
         }
 
@@ -62,7 +61,6 @@ class tx_rnbase_view_Base
         if (!empty($subpart)) {
             $templateCode = tx_rnbase_util_Templates::getSubpart($templateCode, $subpart);
             if (!strlen($templateCode)) {
-                tx_rnbase::load('tx_rnbase_util_Misc');
                 tx_rnbase_util_Misc::mayday('SUBPART NOT FOUND: '.$subpart);
             }
         }

--- a/Legacy/view/class.tx_rnbase_view_phpTemplateEngine.php
+++ b/Legacy/view/class.tx_rnbase_view_phpTemplateEngine.php
@@ -31,7 +31,6 @@
  *
  * @author René Nitzsche <rene@system25.de>
  */
-tx_rnbase::load('tx_rnbase_view_Base');
 
 /**
  * Base class for all views.

--- a/mod/base/class.tx_rnbase_mod_base_Lister.php
+++ b/mod/base/class.tx_rnbase_mod_base_Lister.php
@@ -505,7 +505,6 @@ abstract class tx_rnbase_mod_base_Lister
      */
     protected function showFreeTextSearchForm(&$marker, $key, array $options = [])
     {
-        tx_rnbase::load('tx_rnbase_mod_Util');
         $searchstring = tx_rnbase_mod_Util::getModuleValue($key, $this->getModule(), [
             'changed' => Tx_Rnbase_Utility_T3General::_GP('SET'),
         ]);
@@ -523,7 +522,6 @@ abstract class tx_rnbase_mod_base_Lister
             0 => $GLOBALS['LANG']->getLL('label_select_hide_hidden'),
             1 => $GLOBALS['LANG']->getLL('label_select_show_hidden'),
         ];
-        tx_rnbase::load('tx_rnbase_mod_Util');
         $selectedItem = tx_rnbase_mod_Util::getModuleValue('showhidden', $this->getModule(), [
             'changed' => Tx_Rnbase_Utility_T3General::_GP('SET'),
         ]);

--- a/mod/class.tx_rnbase_mod_BaseModFunc.php
+++ b/mod/class.tx_rnbase_mod_BaseModFunc.php
@@ -22,11 +22,8 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 abstract class tx_rnbase_mod_BaseModFunc implements tx_rnbase_mod_IModFunc
 {

--- a/mod/class.tx_rnbase_mod_BaseModule.php
+++ b/mod/class.tx_rnbase_mod_BaseModule.php
@@ -25,14 +25,8 @@ use Sys25\RnBase\Utility\Arrays;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility_Icons');
-tx_rnbase::load('Tx_Rnbase_Backend_Module_Base');
-tx_rnbase::load('Tx_Rnbase_Utility_T3General');
 
 /**
  * Fertige Implementierung eines BE-Moduls. Das Modul ist dabei nur eine Hülle für die einzelnen Modulfunktionen.
@@ -254,9 +248,6 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
     public function getConfigurations()
     {
         if (!$this->configurations) {
-            tx_rnbase::load('tx_rnbase_util_Misc');
-            tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-
             tx_rnbase_util_Misc::prepareTSFE(); // Ist bei Aufruf aus BE notwendig!
             $cObj = tx_rnbase_util_TYPO3::getContentObject();
 
@@ -320,8 +311,6 @@ abstract class tx_rnbase_mod_BaseModule extends Tx_Rnbase_Backend_Module_Base im
         $this->content .= $this->getDoc()->endPage();
 
         $params = $markerArray = $subpartArray = $wrappedSubpartArray = [];
-        tx_rnbase::load('tx_rnbase_util_BaseMarker');
-        tx_rnbase::load('tx_rnbase_util_Templates');
         tx_rnbase_util_BaseMarker::callModules($this->content, $markerArray, $subpartArray, $wrappedSubpartArray, $params, $this->getConfigurations()->getFormatter());
         $content = tx_rnbase_util_Templates::substituteMarkerArrayCached($this->content, $markerArray, $subpartArray, $wrappedSubpartArray);
 

--- a/mod/class.tx_rnbase_mod_ExtendedModFunc.php
+++ b/mod/class.tx_rnbase_mod_ExtendedModFunc.php
@@ -22,11 +22,8 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_mod_IModule');
 tx_rnbase::load('tx_rnbase_mod_IModFunc');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 /**
  * ModFunc mit SubSelector und SubMenu.

--- a/mod/class.tx_rnbase_mod_Util.php
+++ b/mod/class.tx_rnbase_mod_Util.php
@@ -22,8 +22,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility_Icons');
 
 class tx_rnbase_mod_Util
 {

--- a/tests/Classes/Backend/UtilityTest.php
+++ b/tests/Classes/Backend/UtilityTest.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Backend_Utility');
 
 /**
  * tx_rnbase_tests_controller_testcase.

--- a/tests/Classes/Domain/Collection/BaseTest.php
+++ b/tests/Classes/Domain/Collection/BaseTest.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('Tx_Rnbase_Domain_Collection_Base');
 
 /**
  * collection unit tests.

--- a/tests/Classes/Domain/Repository/PersistenceRepositoryTest.php
+++ b/tests/Classes/Domain/Repository/PersistenceRepositoryTest.php
@@ -62,7 +62,6 @@ class Tx_Rnbase_Domain_Repository_PersistenceRepositoryTest extends tx_rnbase_te
      */
     public function testIsModelWrapperClassWithRightClass()
     {
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Base');
         self::assertTrue(
             $this->callInaccessibleMethod(
                 $this->getRepository(),
@@ -287,15 +286,12 @@ class Tx_Rnbase_Domain_Repository_PersistenceRepositoryTest extends tx_rnbase_te
     protected function getRepository(
         array $methods = []
     ) {
-        tx_rnbase::load('Tx_Rnbase_Database_Connection');
         $connection = $this->getMock(
             'Tx_Rnbase_Database_Connection',
             get_class_methods('Tx_Rnbase_Database_Connection')
         );
-        tx_rnbase::load('Tx_Rnbase_Domain_Model_Base');
         $model = $this->getModel(null, 'Tx_Rnbase_Domain_Model_Base');
 
-        tx_rnbase::load('Tx_Rnbase_Domain_Repository_PersistenceRepository');
         $repo = $this->getMockForAbstractClass(
             'Tx_Rnbase_Domain_Repository_PersistenceRepository',
             [],

--- a/tests/Classes/Frontend/Filter/Utility/CategoryTest.php
+++ b/tests/Classes/Frontend/Filter/Utility/CategoryTest.php
@@ -27,8 +27,6 @@ use Sys25\RnBase\Frontend\Request\Parameters;
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-\tx_rnbase::load('Tx_Rnbase_Category_SearchUtility');
-\tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
 
 /**
  * Tx_Rnbase_Category_FilterUtilityTest.

--- a/tests/Classes/Utility/TcaToolTest.php
+++ b/tests/Classes/Utility/TcaToolTest.php
@@ -21,7 +21,6 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
-tx_rnbase::load('Tx_Rnbase_Utility_TcaTool');
 
 /**
  * Tx_Rnbase_Utility_TcaToolTest.

--- a/tests/action/class.tx_rnbase_tests_action_BaseIOC_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_BaseIOC_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_action_BaseIOC');
 
 /**
  * tx_rnbase_tests_action_BaseIOC_testcase.

--- a/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_action_CacheHandlerDefault');
 
 /**
  * tests for tx_rnbase_util_Templates.

--- a/tests/class.tx_rnbase_tests_Logger_testcase.php
+++ b/tests/class.tx_rnbase_tests_Logger_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Logger');
-
 class tx_rnbase_tests_Logger_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testLogger()

--- a/tests/class.tx_rnbase_tests_basemarker_testcase.php
+++ b/tests/class.tx_rnbase_tests_basemarker_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-
 class tx_rnbase_tests_basemarker_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testContainsMarker()

--- a/tests/class.tx_rnbase_tests_cache_testcase.php
+++ b/tests/class.tx_rnbase_tests_cache_testcase.php
@@ -22,13 +22,10 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TYPO3');
-
 class tx_rnbase_tests_cache_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testCacheManager()
     {
-        tx_rnbase::load('tx_rnbase_cache_Manager');
         $cache = tx_rnbase_cache_Manager::getCache('__rnbaseMgrCache__');
         $this->assertTrue(is_object($cache), 'No Cache instanciated');
     }

--- a/tests/class.tx_rnbase_tests_calendar_testcase.php
+++ b/tests/class.tx_rnbase_tests_calendar_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Calendar');
-
 class tx_rnbase_tests_calendar_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testCalendar()

--- a/tests/class.tx_rnbase_tests_configurations_testcase.php
+++ b/tests/class.tx_rnbase_tests_configurations_testcase.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
 
 class tx_rnbase_tests_configurations_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/class.tx_rnbase_tests_controller_testcase.php
+++ b/tests/class.tx_rnbase_tests_controller_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_controller');
-tx_rnbase::load('tx_rnbase_exception_IHandler');
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
 
 class tx_rnbase_dummyController extends tx_rnbase_controller

--- a/tests/class.tx_rnbase_tests_listbuilder_testcase.php
+++ b/tests/class.tx_rnbase_tests_listbuilder_testcase.php
@@ -22,9 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-tx_rnbase::load('tx_rnbase_util_Typo3Classes');
-
 class tx_rnbase_tests_listbuilder_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function setup()
@@ -130,7 +127,6 @@ class tx_rnbase_tests_listbuilder_testcase extends tx_rnbase_tests_BaseTestCase
     private function getModels()
     {
         $models = [];
-        tx_rnbase::load('tx_rnbase_model_media');
         $models[] = new tx_rnbase_model_media(['uid' => 22, 'file_name' => 'file22.jpg']);
         $models[] = new tx_rnbase_model_media(['uid' => 33, 'file_name' => 'file33.jpg']);
 

--- a/tests/class.tx_rnbase_tests_misc_testcase.php
+++ b/tests/class.tx_rnbase_tests_misc_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Misc');
-
 class tx_rnbase_dummyMisc extends tx_rnbase_util_Misc
 {
     public static function callGetErrorMailHtml($e, $actionName)

--- a/tests/class.tx_rnbase_tests_rnbase_testcase.php
+++ b/tests/class.tx_rnbase_tests_rnbase_testcase.php
@@ -49,7 +49,6 @@ class tx_rnbase_tests_rnbase_testcase extends tx_rnbase_tests_BaseTestCase
 
     private function isExtBasePossible()
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
         // TODO: bessere Testklasse finden
         return false && tx_rnbase_util_TYPO3::isExtLoaded('extbase') &&
             tx_rnbase_util_TYPO3::isExtMinVersion('t3sponsors', 2001);

--- a/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
+++ b/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
@@ -24,11 +24,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
 
-/*
- * benötigte Klassen einbinden.
- */
-tx_rnbase::load('tx_rnbase_mod_IDecorator');
-
 /**
  * Diese Klasse ist für die Darstellung von Elementen im Backend verantwortlich.
  */

--- a/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
+++ b/tests/mod/class.tx_rnbase_tests_mod_Tables_testcase.php
@@ -22,9 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_mod_Tables');
-tx_rnbase::load('tx_rnbase_util_FormTool');
-
 class tx_rnbase_tests_mod_Tables_testcase extends tx_rnbase_tests_BaseTestCase
 {
     /**

--- a/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
+++ b/tests/mod/linker/class.tx_rnbase_tests_mod_linker_ShowDetails_testcase.php
@@ -22,7 +22,6 @@
  * This copyright notice MUST APPEAR in all copies of the script!
  */
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_data');
 
 /**
  * tests for tx_rnbase_mod_linker_ShowDetails.

--- a/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Base_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_base');
 
 class tx_rnbase_tests_model_Base_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Data_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_model_data');
 
 /**
  * @author Michael Wagner <michael.wagner@dmk-ebusiness.de>

--- a/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
+++ b/tests/model/class.tx_rnbase_tests_model_Media_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_model_media');
-
 /**
  * @author Hannes Bochmann <hannes.bochmann@dmk-business.de>
  */

--- a/tests/util/class.tx_rnbase_tests_util_DB_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_DB_testcase.php
@@ -22,10 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_DB');
-tx_rnbase::load('tx_rnbase_util_SearchBase');
-tx_rnbase::load('Tx_Rnbase_Database_Connection');
-
 class tx_rnbase_tests_util_DB_testcase extends tx_rnbase_tests_BaseTestCase
 {
     /**

--- a/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Dates_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Dates');
-
 class tx_rnbase_tests_util_Dates_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testDatetimeGetTimeStamp()

--- a/tests/util/class.tx_rnbase_tests_util_Extensions_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Extensions_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Extensions');
 
 /**
  * tx_rnbase_tests_util_Extensions_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Files_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Files_testcase.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Files');
 
 /**
  * tx_rnbase_tests_util_Files_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Lock_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Lock');
 
 /**
  * Basis Testcase.

--- a/tests/util/class.tx_rnbase_tests_util_Network_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Network_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Network');
 
 /**
  * tx_rnbase_tests_util_Network_testcase.

--- a/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_PageBrowser_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_PageBrowser');
 
 class tx_rnbase_tests_util_PageBrowser_testcase extends tx_rnbase_tests_BaseTestCase
 {

--- a/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SearchBase_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_DB');
-
 class tx_rnbase_tests_util_SearchBase_testcase extends tx_rnbase_tests_BaseTestCase
 {
     public function testSearchFieldJoinedWithoutValue()

--- a/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_SimpleMarker');
 tx_rnbase::load('tx_rnbase_util_TS');
 
 class tx_rnbase_util_SimpleMarkerTests extends tx_rnbase_util_SimpleMarker

--- a/tests/util/class.tx_rnbase_tests_util_Spyc_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Spyc_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Spyc');
 
 /**
  * @author Rene Nitzsche <rene@system25.de>

--- a/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
@@ -22,7 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Strings');
 
 /**
  * @author Rene Nitzsche <rene@system25.de>

--- a/tests/util/class.tx_rnbase_tests_util_TCA_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_TCA_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_TCA');
 
 /**
  * tx_rnbase_tests_util_TCA Tests.

--- a/tests/util/class.tx_rnbase_tests_util_TYPO3_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_TYPO3_testcase.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_TCA');
-
 /**
  * @author Hannes Bochmann <hannes.bochmann@dmk-business.de>
  */

--- a/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
@@ -25,9 +25,7 @@
 use TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 
-tx_rnbase::load('tx_rnbase_util_Network');
 tx_rnbase::load('tx_rnbase_tests_BaseTestCase');
-tx_rnbase::load('tx_rnbase_util_Templates');
 
 /**
  * tests for tx_rnbase_util_Templates.

--- a/util/class.tx_rnbase_util_BEPager.php
+++ b/util/class.tx_rnbase_util_BEPager.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_FormTool');
-
 /**
  * Pager für BE-Module.
  */

--- a/util/class.tx_rnbase_util_FormTool.php
+++ b/util/class.tx_rnbase_util_FormTool.php
@@ -21,7 +21,6 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
-tx_rnbase::load('Tx_Rnbase_Backend_Form_ToolBox');
 
 /**
  * Diese Klasse stellt hilfreiche Funktionen zur Erstellung von Formularen

--- a/util/class.tx_rnbase_util_FormatUtil.php
+++ b/util/class.tx_rnbase_util_FormatUtil.php
@@ -21,7 +21,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
-tx_rnbase::load('tx_rnbase_util_Strings');
 
 /**
  * Contains utility functions for formatting

--- a/util/class.tx_rnbase_util_Json.php
+++ b/util/class.tx_rnbase_util_Json.php
@@ -95,8 +95,6 @@ define('SERVICES_JSON_LOOSE_TYPE', 16);
  */
 define('SERVICES_JSON_SUPPRESS_ERRORS', 32);
 
-tx_rnbase::load('tx_rnbase_util_Strings');
-
 /**
  * Converts to and from JSON format.
  *

--- a/util/class.tx_rnbase_util_Link.php
+++ b/util/class.tx_rnbase_util_Link.php
@@ -29,7 +29,6 @@ use Sys25\RnBase\Utility\Arrays;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-tx_rnbase::load('tx_rnbase_util_Network');
 
 /**
  * This class is a wrapper around \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::typoLink.
@@ -527,7 +526,6 @@ class tx_rnbase_util_Link
     public function redirect($httpStatus = null)
     {
         session_write_close();
-        tx_rnbase::load('tx_rnbase_util_Network');
         tx_rnbase_util_Network::redirect($this->makeUrl(false), $httpStatus);
     }
 

--- a/util/class.tx_rnbase_util_ListBuilder.php
+++ b/util/class.tx_rnbase_util_ListBuilder.php
@@ -24,8 +24,6 @@ use Sys25\RnBase\Utility\Debug;
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_ListBuilderInfo');
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
 tx_rnbase::load('tx_rnbase_util_IListProvider');
 
 /**

--- a/util/class.tx_rnbase_util_Lock.php
+++ b/util/class.tx_rnbase_util_Lock.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Files');
-
 /**
  * Util to handle locking of processes.
  *
@@ -201,7 +199,6 @@ class tx_rnbase_util_Lock
             tx_rnbase_util_Files::mkdir_deep(dirname($fileName));
         }
         if (!tx_rnbase_util_Files::writeFile($fileName, time(), true)) {
-            tx_rnbase::load('tx_rnbase_util_Logger');
             tx_rnbase_util_Logger::warn(
                 'Lock file could not be created for "'.$this->getName().'" process!',
                 'rn_base',

--- a/util/class.tx_rnbase_util_MediaMarker.php
+++ b/util/class.tx_rnbase_util_MediaMarker.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_SimpleMarker');
-
 if (tx_rnbase_util_Extensions::isLoaded('dam')) {
     require_once tx_rnbase_util_Extensions::extPath('dam').'lib/class.tx_dam_db.php';
 }

--- a/util/class.tx_rnbase_util_PageBrowser.php
+++ b/util/class.tx_rnbase_util_PageBrowser.php
@@ -22,8 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Math');
-
 /**
  * Contains utility functions for HTML-Forms.
  */

--- a/util/class.tx_rnbase_util_PageBrowserMarker.php
+++ b/util/class.tx_rnbase_util_PageBrowserMarker.php
@@ -22,10 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_BaseMarker');
-tx_rnbase::load('tx_rnbase_util_PageBrowser');
-tx_rnbase::load('tx_rnbase_util_Math');
-
 /**
  * Contains utility functions for HTML-Forms.
  */

--- a/util/class.tx_rnbase_util_SearchGeneric.php
+++ b/util/class.tx_rnbase_util_SearchGeneric.php
@@ -22,8 +22,6 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_SearchBase');
-
 /**
  * Generic search class. All parameters will be configured.
  *

--- a/util/class.tx_rnbase_util_TCA.php
+++ b/util/class.tx_rnbase_util_TCA.php
@@ -25,8 +25,6 @@ use Sys25\RnBase\Utility\Arrays;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_model_data');
-
 /**
  * TODO: extend from Tx_Rnbase_Util_TCA.
  *
@@ -211,8 +209,6 @@ class tx_rnbase_util_TCA
      */
     public static function loadTCA($tablename)
     {
-        tx_rnbase::load('tx_rnbase_util_TYPO3');
-
         if (tx_rnbase_util_TYPO3::isTYPO80OrHigher()) {
             if (TYPO3_MODE === 'FE' && isset($_REQUEST['eID'])) {
                 $eidUtility = tx_rnbase_util_Typo3Classes::getEidUtilityClass();
@@ -327,7 +323,6 @@ class tx_rnbase_util_TCA
         // check eval list
         if (!empty($config['eval'])) {
             // check eval list
-            tx_rnbase::load('tx_rnbase_util_Strings');
             $evalList = tx_rnbase_util_Strings::trimExplode(
                 ',',
                 $config['eval'],

--- a/util/class.tx_rnbase_util_TS.php
+++ b/util/class.tx_rnbase_util_TS.php
@@ -21,8 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('Tx_Rnbase_Utility_TypoScript');
-
 /**
  * Contains utility functions for TypoScript.
  *

--- a/util/db/class.tx_rnbase_util_db_Exception.php
+++ b/util/db/class.tx_rnbase_util_db_Exception.php
@@ -22,7 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_Exception');
 /**
  * Default exception class.
  */

--- a/util/db/class.tx_rnbase_util_db_MsSQL.php
+++ b/util/db/class.tx_rnbase_util_db_MsSQL.php
@@ -21,7 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_db_Exception');
 tx_rnbase::load('tx_rnbase_util_db_IDatabase');
 
 /**

--- a/util/db/class.tx_rnbase_util_db_MySQL.php
+++ b/util/db/class.tx_rnbase_util_db_MySQL.php
@@ -22,7 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************/
 
-tx_rnbase::load('tx_rnbase_util_db_Exception');
 tx_rnbase::load('tx_rnbase_util_db_IDatabase');
 
 /**


### PR DESCRIPTION
This fixes PHPStan errors in extensions that use rn_base.

In addition, this also should slightly improve performance as classes
now are loaded on demand more often.