### PR TITLE
[TASK] Move deprecated class aliases to a migrations file

### DIFF
--- a/Migrations/Code/LegacyClassesForIde.php
+++ b/Migrations/Code/LegacyClassesForIde.php
@@ -1,5 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
+namespace {
+    exit('Access denied');
+}
+
 namespace Sys25\RnBase\Controller\Extbase {
     /**
      * @deprecated
@@ -15,10 +21,12 @@ namespace Sys25\RnBase\Fluid\View {
     class Action extends \Sys25\RnBase\ExtBaseFluid\View\Action
     {
     }
+
     /** @deprecated */
     class Factory extends \Sys25\RnBase\ExtBaseFluid\View\Factory
     {
     }
+
     /** @deprecated */
     class Standalone extends \Sys25\RnBase\ExtBaseFluid\View\Standalone
     {
@@ -30,6 +38,7 @@ namespace Sys25\RnBase\Fluid\ViewHelper {
     class PageBrowserViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowserViewHelper
     {
     }
+
     /** @deprecated */
     class TranslateViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\TranslateViewHelper
     {
@@ -48,26 +57,32 @@ namespace Sys25\RnBase\Fluid\ViewHelper\PageBrowser {
     class CurrentPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\CurrentPageViewHelper
     {
     }
+
     /** @deprecated */
     class FirstPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\FirstPageViewHelper
     {
     }
+
     /** @deprecated */
     class LastPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\LastPageViewHelper
     {
     }
+
     /** @deprecated */
     class NextPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\NextPageViewHelper
     {
     }
+
     /** @deprecated */
     class NormalPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\NormalPageViewHelper
     {
     }
+
     /** @deprecated */
     class PageBaseViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\PageBaseViewHelper
     {
     }
+
     /** @deprecated */
     class PrevPageViewHelper extends \Sys25\RnBase\ExtBaseFluid\ViewHelper\PageBrowser\PrevPageViewHelper
     {


### PR DESCRIPTION
This change moves the chunk from `Legacy/extbasefluid.php`.

This change reduces breakage with PHPStan and Rector.