### PR TITLE
[TASK] Make the Composer namespaces consistent

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -16,7 +16,7 @@ jobs:
                   coverage: none
                   tools: composer:v2
             - name: "Run PHP lint"
-              run: "composer tests:phplint"
+              run: "composer test:phplint"
         strategy:
             fail-fast: false
             matrix:

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
             "mkdir -p .Build/Web/typo3conf/ext/",
             "[ -L .Build/Web/typo3conf/ext/rn_base ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/rn_base"
         ],
-        "tests:phplint": "find *.php Classes Legacy Migrations tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+        "test:phplint": "find *.php Classes Legacy Migrations tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
         "test:phpcs": [
             "[ -e .Build/bin/php-cs-fixer ] || composer update",
             ".Build/bin/php-cs-fixer fix -v --dry-run --diff"
@@ -104,7 +104,7 @@
         ]
     },
     "scripts-descriptions": {
-        "tests:phplint": "Checks all PHP files for syntax errors."
+        "test:phplint": "Checks all PHP files for syntax errors."
     },
     "extra": {
         "typo3/cms": {


### PR DESCRIPTION
The namespace of the PHP linting Composer script should match those of
the other CI-related Composer scripts.