### PR TITLE
[BUGFIX] Add the removed `Tx_Rnbase_Frontend_Plugin` as a class alias

### DIFF
--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -52,6 +52,7 @@ return [
     'Tx_Rnbase_Exception_Base' => \Sys25\RnBase\Exception\BaseException::class,
     'Tx_Rnbase_Exception_PageNotFound404' => \Sys25\RnBase\Exception\PageNotFound404::class,
     'Tx_Rnbase_Frontend_Marker_Utility' => \Sys25\RnBase\Frontend\Marker\MarkerUtility::class,
+    'Tx_Rnbase_Frontend_Plugin' => \TYPO3\CMS\Frontend\Plugin\AbstractPlugin::class,
     'Tx_Rnbase_Interface_Singleton' => \Sys25\RnBase\Typo3Wrapper\Core\SingletonInterface::class,
     'Tx_Rnbase_RecordList_DatabaseRecordList' => \Sys25\RnBase\Typo3Wrapper\RecordList\DatabaseRecordList::class,
     'Tx_Rnbase_Repository_AbstractRepository' => \Sys25\RnBase\Domain\Repository\AbstractRepository::class,

--- a/Migrations/Code/LegacyClassesForIde.php
+++ b/Migrations/Code/LegacyClassesForIde.php
@@ -7,6 +7,11 @@ namespace {
 }
 
 namespace {
+    /** @deprecated use \TYPO3\CMS\Frontend\Plugin\AbstractPlugin instead */
+    class Tx_Rnbase_Frontend_Plugin
+    {
+    }
+
     /** @deprecated */
     interface tx_rnbase_cache_ICache extends \Sys25\RnBase\Cache\CacheInterface
     {

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 		"namelesscoder/typo3-repository-client": "^1.3.1",
 		"nimut/testing-framework": "^5.2.1",
 		"phpunit/phpunit": "^7.5.20",
+		"typo3/cms-frontend": "^7.6 || ^8.7 || ^9.5 || ^10.4",
 		"typo3/cms-scheduler": "^7.6 || ^8.7 || ^9.5 || ^10.4"
 	},
 	"suggest": {


### PR DESCRIPTION
This fixes breakage in the mkforms extension that still uses this class.

Fixes #249