### PR TITLE
[BUGFIX] Move `AbstractController` into its own file

### DIFF
--- a/Legacy/Controller/AbstractController.php
+++ b/Legacy/Controller/AbstractController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sys25\RnBase\Controller;
+
+use Sys25\RnBase\Fluid\View\Action;
+
+/**
+ * @deprecated
+ */
+abstract class AbstractController extends \tx_rnbase_action_BaseIOC
+{
+    protected function handleRequest(&$parameters, &$configurations, &$viewdata)
+    {
+        return $this->doRequest();
+    }
+
+    abstract protected function doRequest();
+
+    protected function getViewClassName()
+    {
+        return Action::class;
+    }
+
+    protected function assignToView($name, $data)
+    {
+        $this->getViewData()->offsetSet($name, $data);
+
+        return $this;
+    }
+
+    protected function getConfigurationValue($confId)
+    {
+        return $this->getConfigurations()->get($this->getConfId().$confId);
+    }
+}

--- a/Migrations/Code/LegacyClassesForIde.php
+++ b/Migrations/Code/LegacyClassesForIde.php
@@ -434,35 +434,3 @@ namespace Sys25\RnBase\Search {
     {
     }
 }
-
-namespace Sys25\RnBase\Controller {
-    /**
-     * @deprecated
-     */
-    abstract class AbstractController extends \tx_rnbase_action_BaseIOC
-    {
-        protected function handleRequest(&$parameters, &$configurations, &$viewdata)
-        {
-            return $this->doRequest();
-        }
-
-        abstract protected function doRequest();
-
-        protected function getViewClassName()
-        {
-            return \Sys25\RnBase\Fluid\View\Action::class;
-        }
-
-        protected function assignToView($name, $data)
-        {
-            $this->getViewData()->offsetSet($name, $data);
-
-            return $this;
-        }
-
-        protected function getConfigurationValue($confId)
-        {
-            return $this->getConfigurations()->get($this->getConfId().$confId);
-        }
-    }
-}


### PR DESCRIPTION
This class has no alias and has some code of its own. So it
needs to reside in its own autoloaded file instead of being only
stubs for the IDE.