### PR TITLE
[BUGFIX] Align an inconsistent interface in a fixture class

### DIFF
--- a/Classes/Backend/Decorator/InterfaceDecorator.php
+++ b/Classes/Backend/Decorator/InterfaceDecorator.php
@@ -2,6 +2,7 @@
 
 namespace Sys25\RnBase\Backend\Decorator;
 
+use Sys25\RnBase\Backend\Module\IModule;
 use Sys25\RnBase\Domain\Model\DataInterface;
 
 /***************************************************************
@@ -30,7 +31,7 @@ use Sys25\RnBase\Domain\Model\DataInterface;
 /**
  * Decorator interface.
  *
- * @method void __construct(tx_rnbase_mod_IModule $mod)
+ * @method void __construct(IModule $mod)
  *
  * @author Michael Wagner
  */
@@ -39,17 +40,12 @@ interface InterfaceDecorator
     /**
      * Formats a value.
      *
-     * @param string                                $columnValue
-     * @param string                                $columnName
-     * @param array                                 $record
+     * @param string $columnValue
+     * @param string $columnName
+     * @param array $record
      * @param DataInterface $entry
      *
      * @return string
      */
-    public function format(
-        $columnValue,
-        $columnName,
-        array $record,
-        DataInterface $entry
-    );
+    public function format($columnValue, $columnName, array $record, DataInterface $entry);
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -521,6 +521,11 @@ parameters:
 			path: tests/class.tx_rnbase_tests_controller_testcase.php
 
 		-
+			message: "#^Access to an undefined property tx_rnbase_tests_fixtures_classes_Decorator\\:\\:\\$mod\\.$#"
+			count: 1
+			path: tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
+
+		-
 			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
 			count: 2
 			path: tests/model/class.tx_rnbase_tests_model_Base_testcase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,4 +23,3 @@ parameters:
 
   excludePaths:
     - Classes/Typo3Wrapper/Service/AuthenticationService.php
-    - tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php

--- a/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
+++ b/tests/fixtures/classes/class.tx_rnbase_tests_fixtures_classes_Decorator.php
@@ -24,31 +24,34 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
 
+use Sys25\RnBase\Backend\Module\IModule;
+use Sys25\RnBase\Domain\Model\DataInterface;
+
 /**
  * Diese Klasse ist für die Darstellung von Elementen im Backend verantwortlich.
  */
 class tx_rnbase_tests_fixtures_classes_Decorator implements tx_rnbase_mod_IDecorator
 {
     /**
-     * @param tx_rnbase_mod_IModule $mod
+     * @param IModule $mod
      */
-    public function __construct(tx_rnbase_mod_IModule $mod)
+    public function __construct(IModule $mod)
     {
         $this->mod = $mod;
     }
 
     /**
-     * @param string               $value
-     * @param string               $colName
-     * @param array                $record
-     * @param tx_rnbase_model_base $item
+     * @param string $columnValue
+     * @param string $columnName
+     * @param array $record
+     * @param DataInterface $entry
      */
-    public function format($value, $colName, $record, tx_rnbase_model_base $item)
+    public function format($columnValue, $columnName, array $record, DataInterface $entry)
     {
-        $ret = $value;
+        $ret = $columnValue;
 
         //wir manipulieren ein bisschen die daten um zu sehen ob der decorator ansprint
-        if ('col1' == $colName) {
+        if ('col1' == $columnName) {
             $ret = str_replace('col1', 'spalte1', $ret);
         }
 


### PR DESCRIPTION
This allows PHPStan to scan the fixture class again. It also fixes
a possible crash in the tests.