### PR TITLE
[TASK] Stop packaging `tests/`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,4 @@
 /phpstan.neon export-ignore
 /phpunit.xml export-ignore
 /sonar-project.properties export-ignore
-# @TODO: add tests folder to ignore again, after removing the tests from autoloading
-#/tests export-ignore
+/tests export-ignore


### PR DESCRIPTION
Now that the test base class is located in `Classes/`, we do not need
to package the `tests/` folder anymore for Packagist.