### PR TITLE
[TASK] Drop the TER repository client package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.1.0",
 		"mikey179/vfsstream": "^1.6.10",
-		"namelesscoder/typo3-repository-client": "^1.3.1",
 		"nimut/testing-framework": "^5.2.1",
 		"phpstan/phpstan": "^0.12.99",
 		"phpstan/phpstan-phpunit": "^0.12.22",


### PR DESCRIPTION
We now are using a predefined GitHub action for creating TER releases
and don't need this dependency anymore.