### PR TITLE
[CLEANUP] Stop using `__LINE__` as array key for data providers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -506,16 +506,6 @@ parameters:
 			path: tests/Classes/ExtBaseFluid/ViewHelper/BaseViewHelperTest.php
 
 		-
-			message: "#^Array has 4 duplicate keys with value 125 \\(__LINE__, __LINE__, __LINE__, __LINE__\\)\\.$#"
-			count: 1
-			path: tests/Classes/Utility/CryptTest.php
-
-		-
-			message: "#^Array has 3 duplicate keys with value 246 \\(__LINE__, __LINE__, __LINE__\\)\\.$#"
-			count: 1
-			path: tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
-
-		-
 			message: "#^Call to an undefined method tx_rnbase_dummyController\\:\\:getErrorMailHtml\\(\\)\\.$#"
 			count: 1
 			path: tests/class.tx_rnbase_tests_controller_testcase.php
@@ -531,24 +521,9 @@ parameters:
 			path: tests/model/class.tx_rnbase_tests_model_Base_testcase.php
 
 		-
-			message: "#^Array has 8 duplicate keys with value 134 \\(__LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__\\)\\.$#"
-			count: 1
-			path: tests/util/class.tx_rnbase_tests_util_Link_testcase.php
-
-		-
-			message: "#^Array has 8 duplicate keys with value 79 \\(__LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__, __LINE__\\)\\.$#"
-			count: 1
-			path: tests/util/class.tx_rnbase_tests_util_Link_testcase.php
-
-		-
 			message: "#^Undefined variable\\: \\$cObj$#"
 			count: 1
 			path: tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
-
-		-
-			message: "#^Array has 3 duplicate keys with value 70 \\(__LINE__, __LINE__, __LINE__\\)\\.$#"
-			count: 1
-			path: tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
 
 		-
 			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\TimeTracker\\\\NullTimeTracker not found\\.$#"

--- a/tests/Classes/Utility/CryptTest.php
+++ b/tests/Classes/Utility/CryptTest.php
@@ -117,33 +117,33 @@ class CryptTest extends BaseTestCase
     /**
      * Gets the array for the testCryption testcase.
      *
-     * @return array
+     * @return array<int, array<string, array<string, string|bool>>>
      */
     public function getCryptionData()
     {
         return [
-            __LINE__ => [
+            [
                 'config' => [
                     'key' => 'FoOB4r',
                     'urlencode' => false,
                     'base64' => false,
                 ],
             ],
-            __LINE__ => [
+            [
                 'config' => [
                     'key' => 'Crypt',
                     'urlencode' => false,
                     'base64' => true,
                 ],
             ],
-            __LINE__ => [
+            [
                 'config' => [
                     'key' => 'S3cure',
                     'urlencode' => true,
                     'base64' => false,
                 ],
             ],
-            __LINE__ => [
+            [
                 'config' => [
                     'key' => 'K4y',
                     'urlencode' => true,

--- a/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
+++ b/tests/action/class.tx_rnbase_tests_action_CacheHandlerDefault_testcase.php
@@ -235,7 +235,7 @@ class tx_rnbase_tests_action_CacheHandlerDefault_testcase extends BaseTestCase
     /**
      * Returns the test data for the cleanupCacheKey test.
      *
-     * @return array
+     * @return array<int, array<string, string, array<string, int>>>
      */
     public function getCleanupCacheKeyData()
     {
@@ -243,17 +243,17 @@ class tx_rnbase_tests_action_CacheHandlerDefault_testcase extends BaseTestCase
         $s124 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789abcdefghijklmnopqrstuvwxyz--ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789abcdefghijklmnopqrstuvwxyz';
 
         return [
-            __LINE__ => [
+            [
                 'initialKey' => 'myaction._caching.',
                 'cleanedKey' => 'myaction_caching_',
                 'config' => [],
             ],
-            __LINE__ => [
+            [
                 'initialKey' => 'abcABC!"§$%&/()=?+#*\'-.,_:;',
                 'cleanedKey' => 'abcABC_%&_-_',
                 'config' => [],
             ],
-            __LINE__ => [
+            [
                 'initialKey' => $s124,
                 'cleanedKey' => substr($s124, 0, 50 - 33).'-'.md5($s124),
                 'config' => ['keylength' => 50],

--- a/tests/util/class.tx_rnbase_tests_util_Link_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Link_testcase.php
@@ -70,132 +70,132 @@ class tx_rnbase_tests_util_Link_testcase extends BaseTestCase
     /**
      * Liefert die Daten für den testMakeUrlOrTag testcase.
      *
-     * @return array
+     * @return array<int, array<string, string|bool>>
      */
     public function getMakeUrlOrTagData()
     {
         return [
             // makeUrl
-            __LINE__ => [
+            [
                 'typolink' => 'service/faq.html',
                 'absUrl' => false,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => 'service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => 'http://www.system25.de/service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '//www.system25.de/service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '/service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => 'http://www.digedag.de/service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '//www.digedag.de/service/faq.html',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => 'http://www.system25.de/service/faq.html',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '//www.digedag.de/service/faq.html',
                 'absUrl' => true,
                 'schema' => '',
                 'expected' => tx_rnbase_util_Misc::getIndpEnv('TYPO3_REQUEST_DIR').'service/faq.html',
             ],
-            __LINE__ => [
+            [
                     'typolink' => '//www.digedag.de/service/faq.html',
                     'absUrl' => true,
                     'schema' => false,
                     'expected' => tx_rnbase_util_Misc::getIndpEnv('TYPO3_REQUEST_DIR').'service/faq.html',
             ],
             // makeTag
-            __LINE__ => [
+            [
                 'typolink' => '<img src="service/faq.jpg" />',
                 'absUrl' => false,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<img src="service/faq.jpg" />',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<img src="service/faq.jpg" />',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<img src="http://www.system25.de/service/faq.jpg" />',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="//www.system25.de/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="http://www.digedag.de/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',
                 'expected' => '<a href="http://www.system25.de/service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="http://www.digedag.de/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => '',
                 'expected' => '<a href="'.tx_rnbase_util_Misc::getIndpEnv('TYPO3_REQUEST_DIR').'service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            __LINE__ => [
+            [
                 'typolink' => '<a href="http://www.digedag.de/service/faq.html">FAQ</a>',
                 'absUrl' => true,
                 'schema' => false,
                 'expected' => '<a href="'.tx_rnbase_util_Misc::getIndpEnv('TYPO3_REQUEST_DIR').'service/faq.html">FAQ</a>',
                 'method' => 'makeTag',
             ],
-            // invalide tags bleiben unangetatset!
-            __LINE__ => [
+            // invalide tags bleiben unangetastet!
+            [
                 'typolink' => 'a href="service/faq.html">FAQ</a',
                 'absUrl' => true,
                 'schema' => 'http://www.system25.de/',

--- a/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Strings_testcase.php
@@ -62,22 +62,22 @@ class tx_rnbase_tests_util_Strings_testcase extends BaseTestCase
     /**
      * Liefert die Daten für den testIsLastPartOfStr testcase.
      *
-     * @return array
+     * @return array<int, array<string, string|bool>>
      */
     public function getIsLastPartOfStrData()
     {
         return [
-            __LINE__ => [
+            [
                 'haystack' => 'test',
                 'needle' => 'test',
                 'expected' => true,
             ],
-            __LINE__ => [
+            [
                 'haystack' => 'Hallo Welt',
                 'needle' => 'Welt',
                 'expected' => true,
             ],
-            __LINE__ => [
+            [
                 'haystack' => 'Hallo Welt',
                 'needle' => 'Hallo',
                 'expected' => false,


### PR DESCRIPTION
This avoids duplicate key warnings.