### PR TITLE
[TASK] Stop using the deprecated `NullTimeTracker`

### DIFF
--- a/Classes/Utility/Typo3Classes.php
+++ b/Classes/Utility/Typo3Classes.php
@@ -128,15 +128,6 @@ class Typo3Classes
             $enabled = (bool) $_COOKIE[$beCookie];
         }
 
-        // for typo3 6 or 7 we has to initialise a NullTimeTracker if tracker is disabled
-        if (!TYPO3::isTYPO80OrHigher()) {
-            if ($enabled) {
-                return new \TYPO3\CMS\Core\TimeTracker\TimeTracker();
-            }
-
-            return new \TYPO3\CMS\Core\TimeTracker\NullTimeTracker();
-        }
-
         return new \TYPO3\CMS\Core\TimeTracker\TimeTracker($enabled);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -421,11 +421,6 @@ parameters:
 			path: Classes/Utility/TYPO3.php
 
 		-
-			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\TimeTracker\\\\NullTimeTracker not found\\.$#"
-			count: 1
-			path: Classes/Utility/Typo3Classes.php
-
-		-
 			message: "#^Class Sys25\\\\RnBase\\\\Fluid\\\\View\\\\Action not found\\.$#"
 			count: 1
 			path: Legacy/Controller/AbstractController.php
@@ -519,9 +514,4 @@ parameters:
 			message: "#^Undefined variable\\: \\$cObj$#"
 			count: 1
 			path: tests/util/class.tx_rnbase_tests_util_SimpleMarker_testcase.php
-
-		-
-			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\TimeTracker\\\\NullTimeTracker not found\\.$#"
-			count: 1
-			path: tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
 

--- a/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
+++ b/tests/util/class.tx_rnbase_tests_util_Templates_testcase.php
@@ -23,7 +23,6 @@
 ***************************************************************/
 
 use Sys25\RnBase\Testing\BaseTestCase;
-use TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 
 /**
@@ -145,14 +144,12 @@ class tx_rnbase_tests_util_Templates_testcase extends BaseTestCase
     private function setTTOn()
     {
         $GLOBALS['TT'] = new TimeTracker();
-
         $GLOBALS['TT']->start();
     }
 
     private function setTTOff()
     {
-        $GLOBALS['TT'] = new NullTimeTracker();
-        $GLOBALS['TT']->start();
+        $GLOBALS['TT'] = new TimeTracker(false);
     }
 
     public static $template = '


### PR DESCRIPTION
This class was deprecated in TYPO3 8.0 and should not be used anymore.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.0/Deprecation-73185-DeprecateNullTimeTracker.html