### PR TITLE
[BUGFIX] Fix a boolean cast

### DIFF
--- a/Classes/Backend/Module/ExtendedModFunc.php
+++ b/Classes/Backend/Module/ExtendedModFunc.php
@@ -198,7 +198,7 @@ abstract class ExtendedModFunc implements IModFunc
             $msg = $message['message'];
             $title = $message['title'];
             $severity = $message['severity'];
-            $store = boolean($message['storeinsession']);
+            $store = (bool) $message['storeinsession'];
         } else {
             $msg = $message;
             $title = $handler->getSubLabel();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,11 +41,6 @@ parameters:
 			path: Classes/Backend/Module/ExtendedModFunc.php
 
 		-
-			message: "#^Function boolean not found\\.$#"
-			count: 1
-			path: Classes/Backend/Module/ExtendedModFunc.php
-
-		-
 			message: "#^Access to an undefined property Sys25\\\\RnBase\\\\Backend\\\\Template\\\\Override\\\\DocumentTemplate\\:\\:\\$JScode\\.$#"
 			count: 1
 			path: Classes/Backend/Template/Override/DocumentTemplate.php


### PR DESCRIPTION
There is no function `boolean` in PHP for casting to a boolean.